### PR TITLE
[Hotfix/OAuth] : #7 Security, OAuth 관련 리팩토링 및 버그 수정

### DIFF
--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/Article.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/Article.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArticleBookmark.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArticleBookmark.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArticleLike.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArticleLike.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArtistLike.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArtistLike.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/CommentLike.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/CommentLike.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/Debate.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/Debate.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
 import jakarta.persistence.*;
 import lombok.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/DebateChat.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/DebateChat.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/Report.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/Report.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ReviewLike.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ReviewLike.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.wiki.command.application.domain.Review;
 import jakarta.persistence.*;
 import lombok.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/UserAlbum.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/UserAlbum.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/UserGear.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/UserGear.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/SuccessCode.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/SuccessCode.java
@@ -13,6 +13,8 @@ public enum SuccessCode {
     // 200
     SUCCESS(HttpStatus.OK, "OK"),
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
+    REFRESH_SUCCESS(HttpStatus.OK, "Refresh 요청 성공"),
+    DEV_TOKEN_CREATE_SUCCESS(HttpStatus.OK, "개발자 전용 토큰 생성 성공"),
 
     // 201
     CREATE_SUCCESS(HttpStatus.CREATED, "Created"),

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/config/SecurityConfig.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/config/SecurityConfig.java
@@ -16,7 +16,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -33,8 +32,8 @@ public class SecurityConfig {
 
         http.csrf(csrf -> csrf.disable());
         http.authorizeHttpRequests(config -> config
-                        .requestMatchers("/api/v1/auth/logout", "/api/v1/auth/refresh").authenticated() // 테스트를 위해 임시로 설정
-                        .anyRequest().permitAll()
+                        .requestMatchers("/api/v1/developer-token").permitAll() // 개발자용 토큰 요청 허용
+                        .anyRequest().authenticated() // 테스트를 위해 임시로 설정
                 )
                 .formLogin(config -> config.disable()) // 폼 로그인 비활성화
                 .httpBasic(config -> config.disable()) // HTTP Basic 인증 비활성화

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/config/SecurityConfig.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/config/SecurityConfig.java
@@ -32,7 +32,9 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http.csrf(csrf -> csrf.disable());
-        http.authorizeHttpRequests(config -> config.anyRequest().permitAll()
+        http.authorizeHttpRequests(config -> config
+                        .requestMatchers("/api/v1/auth/logout", "/api/v1/auth/refresh").authenticated() // 테스트를 위해 임시로 설정
+                        .anyRequest().permitAll()
                 )
                 .formLogin(config -> config.disable()) // 폼 로그인 비활성화
                 .httpBasic(config -> config.disable()) // HTTP Basic 인증 비활성화

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/details/CustomOAuthUser.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/details/CustomOAuthUser.java
@@ -1,15 +1,13 @@
 package com.notfound.lpickbackend.security.details;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Getter
 public class CustomOAuthUser implements OAuth2User {

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/details/OAuth2UserDetails.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/details/OAuth2UserDetails.java
@@ -1,13 +1,11 @@
 package com.notfound.lpickbackend.security.details;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /* LPick에서 발급하는 JWT 인증을 위한 UserDetails */
 public class OAuth2UserDetails implements UserDetails {

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/filter/JwtFilter.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/filter/JwtFilter.java
@@ -27,12 +27,14 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        log.info("jwtFilter start");
-
         String path = request.getRequestURI();
 
         // oath2 코드 요청 리다이렉트는 건너 뛰기
-        if (pathMatcher.match("/oauth2/code/**", path) || path.equals("/")) {
+        // 개발자 전용 토큰 요청도 건너 뛰기
+        if (pathMatcher.match("/oauth2/code/**", path) || 
+                path.equals("/") || 
+                pathMatcher.match("/api/v1/developer-token", path)
+        ) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/handler/CustomOAuth2SuccessHandler.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/handler/CustomOAuth2SuccessHandler.java
@@ -1,13 +1,12 @@
 package com.notfound.lpickbackend.security.handler;
 
-import com.notfound.lpickbackend.security.util.CookieUtil;
-import com.notfound.lpickbackend.userinfo.command.application.domain.Auth;
-import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.common.redis.RedisService;
 import com.notfound.lpickbackend.security.details.CustomOAuthUser;
+import com.notfound.lpickbackend.security.util.CookieUtil;
 import com.notfound.lpickbackend.security.util.JwtTokenProvider;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.command.repository.UserInfoCommandRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,9 +17,6 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -68,8 +64,8 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
         String refreshToken = jwtTokenProvider.createRefreshToken(oAuthId, userInfo);
 
         // 쿠키에 저장
-        CookieUtil.addCookie(response, "access_token", accessToken, accessTokenValidity); // 1시간
-        CookieUtil.addCookie(response, "refresh_token", refreshToken, refreshTokenValidity); // 7일
+        CookieUtil.addCookie(response, "access_token", accessToken, accessTokenValidity/1000); // 1시간
+        CookieUtil.addCookie(response, "refresh_token", refreshToken, refreshTokenValidity/1000); // 7일
 
         // redis whiteList에 refreshToken 저장
         redisService.saveWhitelistRefreshToken(oAuthId, refreshToken, refreshTokenValidity, TimeUnit.MILLISECONDS);

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/service/CustomOAuth2UserService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/service/CustomOAuth2UserService.java
@@ -1,7 +1,7 @@
 package com.notfound.lpickbackend.security.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.Tier;
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.Tier;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.security.details.CustomOAuthUser;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/util/CookieUtil.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/util/CookieUtil.java
@@ -1,0 +1,32 @@
+package com.notfound.lpickbackend.security.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+/*
+* Cookie 생성과 삭제를 담당할 Util 클래스
+* 코드 재사용성과 유지보수를 위해 작성
+* */
+public class CookieUtil {
+    
+    // 쿠키 추가 메소드
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAgeInSec) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAgeInSec);
+        response.addCookie(cookie);
+    }
+    
+    // 쿠키 삭제 메소드
+    public static void deleteCookie(HttpServletResponse response, String name) {
+        
+        Cookie cookie = new Cookie(name, null);
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // 즉시 만료
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        response.addCookie(cookie);
+    }
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/security/util/JwtTokenProvider.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/security/util/JwtTokenProvider.java
@@ -65,6 +65,36 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    // Access Token 생성 메서드
+    public String createDevAccessToken(String subject, UserInfo userInfo) {
+
+        Map<String,Object> claims = createClaims(userInfo);
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject) // 사용자 식별자
+                .setIssuedAt(now) // 발급 시간
+                .setExpiration(new Date(now.getTime() + 31536000000L)) // 만료 시간
+                .signWith(key, SignatureAlgorithm.HS512) // 서명 알고리즘
+                .compact();
+    }
+
+    // Refresh Token 생성 메서드
+    public String createDevRefreshToken(String subject, UserInfo userInfo) {
+
+        Map<String,Object> claims = createClaims(userInfo);
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject) // 사용자 식별자
+                .setIssuedAt(now) // 발급 시간
+                .setExpiration(new Date(now.getTime() + 31536000000L)) // 만료 시간
+                .signWith(key, SignatureAlgorithm.HS512) // 서명 알고리즘
+                .compact();
+    }
+
     private Map<String, Object> createClaims(UserInfo userInfo) {
 
         // Claims에 넣기 위해 List<Auth>에서 List<String>으로 변경

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/tier/query/repository/TierCommandRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/tier/query/repository/TierCommandRepository.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.tier.query.repository;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.Tier;
+import com.notfound.lpickbackend.userinfo.command.application.domain.Tier;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TierCommandRepository extends JpaRepository<Tier, String> {

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/controller/UserInfoCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/controller/UserInfoCommandController.java
@@ -9,14 +9,14 @@ import com.notfound.lpickbackend.userinfo.command.application.dto.LogoutRequestD
 import com.notfound.lpickbackend.userinfo.command.application.dto.TokenRefreshRequestDTO;
 import com.notfound.lpickbackend.userinfo.command.application.dto.TokenResponseDTO;
 import com.notfound.lpickbackend.userinfo.command.application.service.UserInfoCommandService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
@@ -81,16 +81,41 @@ public class UserInfoCommandController {
                 response,
                 "access_token",
                 tokenResponseDTO.getAccessToken(),
-                accessTokenValidity
+                accessTokenValidity/1000 // 초 단위라 나누기 1000
         );
         CookieUtil.addCookie(
                 response,
                 "refresh_token",
                 tokenResponseDTO.getRefreshToken(),
-                refreshTokenValidity
+                refreshTokenValidity/1000 // 초 단위라 나누기 1000
         );
 
-        return null;
+        return ResponseEntity.ok(SuccessCode.REFRESH_SUCCESS);
+    }
+
+    /* 개발자 전용 토큰 요청 api */
+    @PostMapping("/developer-token")
+    ResponseEntity<SuccessCode> developerTokenRequest(
+            HttpServletResponse response
+    ) {
+
+        TokenResponseDTO tokenResponseDTO = userCommandService.getDeveloperToken();
+
+        // 쿠키 추가
+        CookieUtil.addCookie(
+                response,
+                "access_token",
+                tokenResponseDTO.getAccessToken(),
+                31536000 // 1년
+        );
+        CookieUtil.addCookie(
+                response,
+                "refresh_token",
+                tokenResponseDTO.getRefreshToken(),
+                31536000 // 1년
+        );
+
+        return ResponseEntity.ok(SuccessCode.DEV_TOKEN_CREATE_SUCCESS);
     }
 
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/controller/UserInfoCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/controller/UserInfoCommandController.java
@@ -3,29 +3,51 @@ package com.notfound.lpickbackend.userinfo.command.application.controller;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.common.exception.SuccessCode;
+import com.notfound.lpickbackend.security.util.CookieUtil;
 import com.notfound.lpickbackend.security.util.UserInfoUtil;
 import com.notfound.lpickbackend.userinfo.command.application.dto.LogoutRequestDTO;
+import com.notfound.lpickbackend.userinfo.command.application.dto.TokenRefreshRequestDTO;
+import com.notfound.lpickbackend.userinfo.command.application.dto.TokenResponseDTO;
 import com.notfound.lpickbackend.userinfo.command.application.service.UserInfoCommandService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
 @RequestMapping("/api/v1")
-@RequiredArgsConstructor
 public class UserInfoCommandController {
 
     private final UserInfoCommandService userCommandService;
+    private final int accessTokenValidity;
+    private final int refreshTokenValidity;
 
-    @PostMapping("/logout")
-    ResponseEntity<SuccessCode> oAuthLogoutRequest(HttpServletRequest request) {
+    public UserInfoCommandController(
+            UserInfoCommandService userCommandService,
+            @Value("${token.access_token_expiration_time}") int accessTokenValidity,
+            @Value("${token.refresh_token_expiration_time}") int refreshTokenValidity
+    ) {
+        this.userCommandService = userCommandService;
+        this.accessTokenValidity = accessTokenValidity;
+        this.refreshTokenValidity = refreshTokenValidity;
+    }
 
-        // 요청 헤더에서 accessToken 추출
-        String accessToken = getAccessTokenFromCookies(request);
+    /*
+    * @CookieValue : HttpServletRequest 에서 해당 Value의 쿠키 추출 후 매개변수 주입.
+    * required 속성 : 해당 쿠키가 존재하지 않을경우 예외처리를 할것인지 안할것인지.. false로 할 시 예외처리 하지 않음.
+    *                CustomError 처리를 위해 false로 설정.
+    * @CookieValue는 스프링 MVC 컨트롤러 메서드 파라미터에서만 동작하는 애노테이션.
+    * */
+    @PostMapping("/auth/logout")
+    ResponseEntity<SuccessCode> oAuthLogoutRequest(
+            HttpServletResponse response,
+            @CookieValue(name = "access_token", required = false) String accessToken
+    ) {
         if (accessToken == null || accessToken.isEmpty()) { // Cookie에 AccessToken이 없을 경우 예외처리
             throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);
         }
@@ -35,20 +57,40 @@ public class UserInfoCommandController {
 
         userCommandService.logout(new LogoutRequestDTO(accessToken, oAuthId));
 
+        // 보안을 위한 기존 쿠키 삭제
+        CookieUtil.deleteCookie(response, "access_token");
+        CookieUtil.deleteCookie(response, "refresh_token");
+
         return ResponseEntity.ok(SuccessCode.LOGOUT_SUCCESS);
     }
 
-    // Cookie에서 AccessToken 추출하는 메소드
-    private String getAccessTokenFromCookies(HttpServletRequest request) {
+    // refresh Token 재발급 요청
+    @PostMapping("/auth/refresh")
+    ResponseEntity<SuccessCode> oAuthRefreshTokenRequest(
+            HttpServletResponse response,
+            @CookieValue(name = "access_token", required = false) String accessToken
+    ) {
 
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) return null;
+        // 인증 객체에서 OAuthId 추출
+        String oAuthId = UserInfoUtil.getOAuthId();
 
-        for (Cookie cookie : cookies) {
-            if ("accessToken".equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
+        TokenResponseDTO tokenResponseDTO = userCommandService.refresh(new TokenRefreshRequestDTO(oAuthId, accessToken));
+
+        // 쿠키 추가
+        CookieUtil.addCookie(
+                response,
+                "access_token",
+                tokenResponseDTO.getAccessToken(),
+                accessTokenValidity
+        );
+        CookieUtil.addCookie(
+                response,
+                "refresh_token",
+                tokenResponseDTO.getRefreshToken(),
+                refreshTokenValidity
+        );
+
         return null;
     }
+
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/Auth.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/Auth.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.AUTO_ENTITIES;
+package com.notfound.lpickbackend.userinfo.command.application.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,17 +12,13 @@ import lombok.*;
 @Getter
 @Setter
 @Entity
-@Table(name = "tier")
-public class Tier {
-
+@Table(name = "auth")
+public class Auth {
     @Id
-    @Column(name = "tier_id", nullable = false, length = 40)
-    private String tierId;
+    @Column(name = "auth_id", nullable = false, length = 40)
+    private String authId;
 
     @Column(name = "name", nullable = false, length = 50)
     private String name;
-
-    @Column(name = "point_scope", nullable = false)
-    private Integer pointScope;
 
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/Tier.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/Tier.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.AUTO_ENTITIES;
+package com.notfound.lpickbackend.userinfo.command.application.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,13 +12,17 @@ import lombok.*;
 @Getter
 @Setter
 @Entity
-@Table(name = "auth")
-public class Auth {
+@Table(name = "tier")
+public class Tier {
+
     @Id
-    @Column(name = "auth_id", nullable = false, length = 40)
-    private String authId;
+    @Column(name = "tier_id", nullable = false, length = 40)
+    private String tierId;
 
     @Column(name = "name", nullable = false, length = 50)
     private String name;
+
+    @Column(name = "point_scope", nullable = false)
+    private Integer pointScope;
 
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/UserAuth.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/UserAuth.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.AUTO_ENTITIES;
+package com.notfound.lpickbackend.userinfo.command.application.domain;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/UserAuthId.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/UserAuthId.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.AUTO_ENTITIES;
+package com.notfound.lpickbackend.userinfo.command.application.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/UserInfo.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/UserInfo.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.AUTO_ENTITIES;
+package com.notfound.lpickbackend.userinfo.command.application.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/dto/TokenRefreshRequestDTO.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/dto/TokenRefreshRequestDTO.java
@@ -1,0 +1,17 @@
+package com.notfound.lpickbackend.userinfo.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+/*
+* LogoutRequestDTO와 내용은 동일하지만 요청의 목적이 다르기에 가시성 + 유지보수성을 위해 별도의 DTO로 분리
+* */
+public class TokenRefreshRequestDTO {
+
+    private String oAuthId;
+    private String accessToken;
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/dto/TokenResponseDTO.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/dto/TokenResponseDTO.java
@@ -1,0 +1,17 @@
+package com.notfound.lpickbackend.userinfo.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+/*
+* 생성된 Token을 전달하는 DTO
+* */
+public class TokenResponseDTO {
+
+    String accessToken;
+    String refreshToken;
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserInfoCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserInfoCommandService.java
@@ -3,9 +3,7 @@ package com.notfound.lpickbackend.userinfo.command.application.service;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.common.redis.RedisService;
-import com.notfound.lpickbackend.security.util.CookieUtil;
 import com.notfound.lpickbackend.security.util.JwtTokenProvider;
-import com.notfound.lpickbackend.userinfo.command.application.domain.Auth;
 import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.command.application.dto.LogoutRequestDTO;
 import com.notfound.lpickbackend.userinfo.command.application.dto.TokenRefreshRequestDTO;
@@ -16,9 +14,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -47,18 +42,15 @@ public class UserInfoCommandService extends DefaultOAuth2UserService {
 
     public void logout(LogoutRequestDTO logoutRequestDTO) {
 
-        log.info("logout service start");
-
         // Token 무효화
         invalidateTokens(logoutRequestDTO.getOAuthId(), logoutRequestDTO.getAccessToken());
 
-        log.info("logout service end");
     }
 
     public TokenResponseDTO refresh(TokenRefreshRequestDTO tokenRefreshRequestDTO) {
 
         String oAuthId = tokenRefreshRequestDTO.getOAuthId();
-        log.info("oAuthId: {}", oAuthId);
+
         // Token 무효화
         invalidateTokens(oAuthId, tokenRefreshRequestDTO.getAccessToken());
 
@@ -83,12 +75,27 @@ public class UserInfoCommandService extends DefaultOAuth2UserService {
      * */
     private void invalidateTokens(String oAuthId, String accessToken) {
 
-        log.info("invalidateTokens service start");
-
         // whiteList에서 OAuthId로 RefreshToken 삭제
         redisService.deleteRefreshToken(oAuthId);
         // BlackList에 AccessToken 추가
         redisService.saveBlacklistAccessToken(accessToken, accessTokenValidity, TimeUnit.MILLISECONDS);
     }
 
+    /* 개발자용 토큰 생성 api */
+    public TokenResponseDTO getDeveloperToken() {
+
+        /* 더미데이터에 존재하는 OAuthId '1' 유저 */
+        UserInfo userInfo = userInfoCommandRepository.findByOauthId("1").orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_USER_INFO)
+        );
+
+        // 개발자용 accessToken, refreshToken 생성
+        String accessToken = jwtTokenProvider.createDevAccessToken("1", userInfo);
+        String refreshToken = jwtTokenProvider.createDevRefreshToken("1", userInfo);
+
+        // redis whiteList에 refreshToken 1년 동안 저장
+        redisService.saveWhitelistRefreshToken("1", refreshToken, 365, TimeUnit.DAYS);
+
+        return new TokenResponseDTO(accessToken, refreshToken);
+    }
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserInfoCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserInfoCommandService.java
@@ -1,29 +1,94 @@
 package com.notfound.lpickbackend.userinfo.command.application.service;
 
+import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.common.redis.RedisService;
+import com.notfound.lpickbackend.security.util.CookieUtil;
+import com.notfound.lpickbackend.security.util.JwtTokenProvider;
+import com.notfound.lpickbackend.userinfo.command.application.domain.Auth;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.command.application.dto.LogoutRequestDTO;
+import com.notfound.lpickbackend.userinfo.command.application.dto.TokenRefreshRequestDTO;
+import com.notfound.lpickbackend.userinfo.command.application.dto.TokenResponseDTO;
+import com.notfound.lpickbackend.userinfo.command.repository.UserInfoCommandRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Service
+@Slf4j
 public class UserInfoCommandService extends DefaultOAuth2UserService {
 
     private final RedisService redisService;
     private final int accessTokenValidity;
+    private final int refreshTokenValidity;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserInfoCommandRepository userInfoCommandRepository;
 
-    public UserInfoCommandService(RedisService redisService, @Value("${token.access_token_expiration_time}") int accessTokenValidity) {
+    public UserInfoCommandService(
+            RedisService redisService,
+            @Value("${token.access_token_expiration_time}") int accessTokenValidity,
+            @Value("${token.refresh_token_expiration_time}") int refreshTokenValidity,
+            JwtTokenProvider jwtTokenProvider,
+            UserInfoCommandRepository userInfoCommandRepository
+    ) {
         this.redisService = redisService;
         this.accessTokenValidity = accessTokenValidity;
+        this.refreshTokenValidity = refreshTokenValidity;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userInfoCommandRepository = userInfoCommandRepository;
     }
 
     public void logout(LogoutRequestDTO logoutRequestDTO) {
 
-        // whiteList에서 OAuthId로 RefreshToken 삭제
-        redisService.deleteRefreshToken(logoutRequestDTO.getOAuthId());
-        // BlackList에 AccessToken 추가
-        redisService.saveBlacklistAccessToken(logoutRequestDTO.getAccessToken(), accessTokenValidity, TimeUnit.MILLISECONDS);
+        log.info("logout service start");
+
+        // Token 무효화
+        invalidateTokens(logoutRequestDTO.getOAuthId(), logoutRequestDTO.getAccessToken());
+
+        log.info("logout service end");
     }
+
+    public TokenResponseDTO refresh(TokenRefreshRequestDTO tokenRefreshRequestDTO) {
+
+        String oAuthId = tokenRefreshRequestDTO.getOAuthId();
+        log.info("oAuthId: {}", oAuthId);
+        // Token 무효화
+        invalidateTokens(oAuthId, tokenRefreshRequestDTO.getAccessToken());
+
+        UserInfo userInfo = userInfoCommandRepository.findByOauthId(oAuthId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_USER_INFO)
+        );
+
+        // accessToken, refreshToken 생성
+        String accessToken = jwtTokenProvider.createAccessToken(oAuthId, userInfo);
+        String refreshToken = jwtTokenProvider.createRefreshToken(oAuthId, userInfo);
+
+        // redis whiteList에 refreshToken 저장
+        redisService.saveWhitelistRefreshToken(oAuthId, refreshToken, refreshTokenValidity, TimeUnit.MILLISECONDS);
+
+        return new TokenResponseDTO(accessToken, refreshToken);
+    }
+
+    /*
+     * AccessToken은 BlackList에 추가, RefreshToken은 White에서 삭제합니다.
+     * RefreshToken 재사용 방지를 위해 AccessToken 및 RefreshToken은 발급과 삭제가 동시에 이루어집니다.
+     * 고민점 : logout과 refresh에 필요한 데이터는 OAuthId, AccessToken으로 동일하기에 두 로직에서 사용되는 DTO를 나눌지, 하나로 사용할지 고민
+     * */
+    private void invalidateTokens(String oAuthId, String accessToken) {
+
+        log.info("invalidateTokens service start");
+
+        // whiteList에서 OAuthId로 RefreshToken 삭제
+        redisService.deleteRefreshToken(oAuthId);
+        // BlackList에 AccessToken 추가
+        redisService.saveBlacklistAccessToken(accessToken, accessTokenValidity, TimeUnit.MILLISECONDS);
+    }
+
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/repository/UserInfoCommandRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/repository/UserInfoCommandRepository.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.userinfo.command.repository;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserAuthQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserAuthQueryRepository.java
@@ -1,7 +1,7 @@
 package com.notfound.lpickbackend.userinfo.query.repository;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserAuth;
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserAuthId;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserAuth;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserAuthId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserInfoQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserInfoQueryRepository.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.userinfo.query.repository;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserTierRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserTierRepository.java
@@ -1,7 +1,7 @@
 package com.notfound.lpickbackend.userinfo.query.repository;
 
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.Tier;
+import com.notfound.lpickbackend.userinfo.command.application.domain.Tier;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserAuthQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserAuthQueryService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.userinfo.query.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserAuth;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserAuth;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.userinfo.command.domain.UserAuthentication;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserInfoQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserInfoQueryService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.userinfo.query.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.query.repository.UserInfoQueryRepository;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/controller/PageRevisionCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/controller/PageRevisionCommandController.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.controller;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.query.service.UserInfoQueryService;
 import com.notfound.lpickbackend.wiki.command.application.dto.request.PageRevisionRequest;
 import com.notfound.lpickbackend.wiki.command.application.service.PageRevisionCommandService;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/controller/WikiBookmarkCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/controller/WikiBookmarkCommandController.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.controller;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.common.exception.SuccessCode;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/controller/WikiReviewCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/controller/WikiReviewCommandController.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.controller;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.common.exception.SuccessCode;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/PageRevision.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/PageRevision.java
@@ -1,7 +1,7 @@
 package com.notfound.lpickbackend.wiki.command.application.domain;
 
 import com.notfound.lpickbackend.AUTO_ENTITIES.TOOL.IdPrefixUtil;
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/Review.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/Review.java
@@ -1,7 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.domain;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
-import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.wiki.command.application.dto.request.ReviewPostRequest;
 import jakarta.persistence.*;
 import lombok.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/WikiBookmark.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/WikiBookmark.java
@@ -1,7 +1,7 @@
 package com.notfound.lpickbackend.wiki.command.application.domain;
 
 import com.notfound.lpickbackend.AUTO_ENTITIES.TOOL.IdPrefixUtil;
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/PageRevisionCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/PageRevisionCommandService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.query.dto.response.UserIdNamePairResponse;
 import com.notfound.lpickbackend.wiki.command.application.domain.PageRevision;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiBookmarkCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiBookmarkCommandService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiBookmark;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
 import com.notfound.lpickbackend.wiki.command.repository.WikiBookmarkCommandRepository;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandService.java
@@ -4,7 +4,7 @@ package com.notfound.lpickbackend.wiki.command.application.service;
 import com.notfound.lpickbackend.AUTO_ENTITIES.Album;
 import com.notfound.lpickbackend.AUTO_ENTITIES.Artist;
 import com.notfound.lpickbackend.AUTO_ENTITIES.Gear;
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.query.service.UserInfoQueryService;
 import com.notfound.lpickbackend.wiki.command.application.domain.PageRevision;
 import com.notfound.lpickbackend.wiki.command.application.dto.request.PageRevisionRequest;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiReviewCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiReviewCommandService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.wiki.command.application.domain.Review;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/query/controller/WikiBookmarkQueryController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/query/controller/WikiBookmarkQueryController.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.query.controller;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.query.service.UserInfoQueryService;
 import com.notfound.lpickbackend.wiki.query.dto.response.WikiBookmarkResponse;
 import com.notfound.lpickbackend.wiki.query.dto.response.WikiPageBookmarkListResponse;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/query/service/WikiBookmarkQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/query/service/WikiBookmarkQueryService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.query.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiBookmark;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
 import com.notfound.lpickbackend.wiki.query.dto.response.WikiBookmarkResponse;

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/security/service/CustomOAuth2UserServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/security/service/CustomOAuth2UserServiceTest.java
@@ -1,7 +1,7 @@
 package com.notfound.lpickbackend.security.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.Tier;
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.Tier;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.TestUtil;
 import com.notfound.lpickbackend.security.details.CustomOAuthUser;
 import com.notfound.lpickbackend.tier.query.repository.TierCommandRepository;

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/PageRevisionCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/PageRevisionCommandServiceTest.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.wiki.command.application.service;
 
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.userinfo.query.dto.response.UserIdNamePairResponse;
 import com.notfound.lpickbackend.wiki.command.application.domain.PageRevision;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandServiceTest.java
@@ -3,7 +3,7 @@ package com.notfound.lpickbackend.wiki.command.application.service;
 import com.notfound.lpickbackend.AUTO_ENTITIES.Album;
 import com.notfound.lpickbackend.AUTO_ENTITIES.Artist;
 import com.notfound.lpickbackend.AUTO_ENTITIES.Gear;
-import com.notfound.lpickbackend.AUTO_ENTITIES.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.UserInfo;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.userinfo.query.service.UserInfoQueryService;


### PR DESCRIPTION
## 📌 PR 제목 
[Hotfix/OAuth] : #7 Security, OAuth 관련 리팩토링 및 버그 수정
---
## 🤔 연관된 이슈
hotfix/OAuth: OAuth 설계 과정 자잘한 버그 수정 #9

## ✨ 요약
1. JWT 인증 과정에서 인증 객체 추출하는 코드를 Header의 Authentication에서 가져오는 방식 -> Cookie에서 추출하는 방식으로 수정
2. Logout시 사용자 쿠키 삭제 추가
3. AccessToken 만료를 대비해서 Refresh 요청 API 구현(추후 Front-end에 Interceptor로 적용 예정)
4. 여러가지 코드들 리팩토링
---

## ✅ 주요 작업
- [x] JWT 인증 과정에서 인증 객체 추출하는 코드를 Header의 Authentication에서 가져오는 방식 -> Cookie에서 추출하는 방식으로 수정
- [x] Logout시 사용자 쿠키 삭제 추가
- [x] AccessToken 만료를 대비해서 Refresh 요청 API 구현
- [x] 여러가지 코드들 리팩토링

---

## 🧪 테스트 방법
- [x] http://localhost:8080/oauth2/authorization/kakao를 통해 로그인 진행 시 쿠키 생성
![image](https://github.com/user-attachments/assets/a6f6a3c6-846d-4298-8592-f161922b6ed3)
- [x] refresh 요청 시 AccessToken 및 RefreshToken 재발급
![image](https://github.com/user-attachments/assets/b2571f06-4a9e-468b-8e08-ee56b2e9fe36)
![image](https://github.com/user-attachments/assets/a6aa3afb-706a-4786-aa8e-3d73af635ae5)
- [x] 개발자 전용 유효기간 1년 토큰 발급 API
![image](https://github.com/user-attachments/assets/d33a9545-48ce-4701-a242-2e89524ea4e2)


## 참고사항
개발자 전용 토큰은 더미데이터 유저(OAuthId : '1')를 사용하였습니다.
패키지 구조를 바꿔서 내용이 바뀐 파일이 상당히 많습니다.