### PR TITLE
feat/UserGear-V2 : 기존 사용자 기기 관련 기능(UserGear) 구현 수정

### DIFF
--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArtistLike.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/AUTO_ENTITIES/ArtistLike.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.AUTO_ENTITIES;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Artist;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Artist;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
 import jakarta.persistence.*;
 import lombok.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseCommandService.java
@@ -1,0 +1,18 @@
+package com.notfound.lpickbackend.common._super;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public abstract class BaseCommandService<T extends BaseEntity, String> {
+    protected abstract JpaRepository<T, String> getRepository();
+
+    @Transactional
+    public T saveEntity(T entity) {
+        return getRepository().save(entity);
+    }
+
+    @Transactional
+    public void deleteById(String id) {
+        getRepository().deleteById(id);
+    }
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseEntity.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.notfound.lpickbackend.common._super;
+
+
+import com.notfound.lpickbackend.AUTO_ENTITIES.TOOL.IdPrefixUtil;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+    @Id
+    @Column(name = "id", nullable = false, length = 40)
+    private String id;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.id == null) {
+            this.id = IdPrefixUtil.get(this.getClass().getSimpleName()) + "_" + UUID.randomUUID();
+        }
+    }
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseEntity.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseEntity.java
@@ -6,15 +6,18 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.UUID;
 
+// SuperBuilder == 자식클래스 빌더 사용 시 슈퍼 클래스 필드까지 빌더에서 활용 가능하게 하는 빌더. 슈퍼 클래스에도 아래와 같이 작성해두어야함.
+@SuperBuilder
 @MappedSuperclass
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public abstract class BaseEntity {
     @Id
     @Column(name = "id", nullable = false, length = 40)

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/_super/BaseQueryService.java
@@ -1,0 +1,26 @@
+package com.notfound.lpickbackend.common._super;
+
+import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common.exception.ErrorCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public abstract class BaseQueryService<T extends BaseEntity, String> {
+    protected abstract JpaRepository<T, String> getRepository();
+    protected abstract ErrorCode notFoundErrorCode();
+
+    @Transactional(readOnly = true)
+    public T findById(String id) {
+        return getRepository()
+                .findById(id)
+                .orElseThrow(() -> new CustomException(notFoundErrorCode()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<T> findAll() {
+        return getRepository().findAll();
+    }
+
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/ErrorCode.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     INVALID_PAGE_REQUEST(HttpStatus.BAD_REQUEST,"page 옵션이 올바르지 않습니다. 음수 등을 작성할 수 없습니다." ),
     ALREADY_FULL_FAVORITE_ALBUM(HttpStatus.BAD_REQUEST, "favorite 리스트가 가득 찼습니다. 더이상 favorite로 지정할 수 없습니다."),
     ALREADY_FULL_FAVORITE_GEAR(HttpStatus.BAD_REQUEST, "favorite 리스트가 가득 찼습니다. 더이상 favorite로 지정할 수 없습니다."),
+    IS_NOT_TEMP_GEAR(HttpStatus.BAD_REQUEST, "허가하려는 Gear는 Temp 상태가 아닙니다."),
 
 
     // 401 에러
@@ -63,6 +64,9 @@ public enum ErrorCode {
 
     NOT_FOUND_USER_GEAR(HttpStatus.NOT_FOUND, "사용자는 해당 음향기기를 지니고 있지 않습니다."),
     NOT_FOUND_GEAR(HttpStatus.NOT_FOUND, "음향기기 정보를 찾을 수 없습니다."),
+    NOT_FOUND_GEAR_CLASS(HttpStatus.NOT_FOUND, "해당 타입의 음향기기 종류를 찾을 수 없습니다."),
+
+
     // 처리 방법에 논의가 필요한 에러 코드 임시할당용
     DO_NOT_KEEP_UP_THIS_ERROR_WHEN_MERGE(HttpStatus.I_AM_A_TEAPOT, "이 에러 코드는 실제 사용 목적이 아닙니다."),
     ;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/ErrorCode.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     ALREADY_HAS_BOOKMARK(HttpStatus.BAD_REQUEST, "이미 추가되어있는 북마크입니다."),
     INVALID_PAGE_REQUEST(HttpStatus.BAD_REQUEST,"page 옵션이 올바르지 않습니다. 음수 등을 작성할 수 없습니다." ),
     ALREADY_FULL_FAVORITE_ALBUM(HttpStatus.BAD_REQUEST, "favorite 리스트가 가득 찼습니다. 더이상 favorite로 지정할 수 없습니다."),
+    ALREADY_FULL_FAVORITE_GEAR(HttpStatus.BAD_REQUEST, "favorite 리스트가 가득 찼습니다. 더이상 favorite로 지정할 수 없습니다."),
+
 
     // 401 에러
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증 실패"),

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/SuccessCode.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/exception/SuccessCode.java
@@ -18,6 +18,8 @@ public enum SuccessCode {
     ARTICLE_UPDATE_SUCESS(HttpStatus.OK, "게시글 수정 성공"),
     USER_ABOUT_UPDATE_SUCESS(HttpStatus.OK, "사용자 소개문 수정 성공"),
     USER_SETTING_UPDATE_SUCESS(HttpStatus.OK, "사용자 설정 수정 성공"),
+    GEAR_UPDATE_SUCESS(HttpStatus.OK, "기기 정보 업데이트 성공"),
+    TEMP_GEAR_APPROVE_SUCESS(HttpStatus.OK, "임시기기 승인 성공"),
 
     // 201
     CREATE_SUCCESS(HttpStatus.CREATED, "Created"),
@@ -27,6 +29,8 @@ public enum SuccessCode {
     BOOKMARK_CREATE_SUCCESS(HttpStatus.CREATED, "북마크 생성 성공"),
     LIKE_CREATE_SUCCESS(HttpStatus.CREATED, "좋아요 생성 성공"),
     RECORD_CREATE_SUCCESS(HttpStatus.CREATED, "레코드파일 S3업로드 성공"),
+    TEMP_GEAR_CREATE_SUCCESS(HttpStatus.CREATED, "임시 음향기기 생성 성공"),
+
 
     // PAGE_REVISION_REVERT_SUCCESS(HttpStatus.OK, "대상 버전으로 되돌리기 성공");
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/redis/RedisConfig.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/redis/RedisConfig.java
@@ -17,7 +17,6 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
-
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port); // 또는 Docker 내부 네트워크라면 host 확인

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/common/util/EnumUtils.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/common/util/EnumUtils.java
@@ -1,0 +1,18 @@
+package com.notfound.lpickbackend.common.util;
+
+/** 프론트엔드에서 전달받은 String이 Enum 내의 name과 동일한지 DB READ 들어가기 전에 선 확인 하기위한 목적의 Util */
+public class EnumUtils {
+
+    /** isValidEnum(GearClass.class, str.upper()) */
+    public static <E extends Enum<E>> boolean isValidEnum(Class<E> enumClass, String name) {
+        if (enumClass == null || name == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(enumClass, name);
+            return true;
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
+    }
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/community/command/domain/CommunityImage.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/community/command/domain/CommunityImage.java
@@ -1,0 +1,27 @@
+package com.notfound.lpickbackend.community.command.domain;
+
+import com.notfound.lpickbackend.common._super.BaseEntity;
+import jakarta.persistence.Entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "community_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommunityImage extends BaseEntity {
+
+
+    @Column(name = "src", nullable = false, length = 255)
+    private String src;
+
+    @Column(name = "type", nullable = false, length = 10)
+    private String type;
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/controller/GearCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/controller/GearCommandController.java
@@ -1,0 +1,4 @@
+package com.notfound.lpickbackend.servicedata.command.application.controller;
+
+public class GearCommandController {
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/controller/GearCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/controller/GearCommandController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -24,7 +25,9 @@ public class GearCommandController {
     @PostMapping("/gear/temp-gear")
     @Operation(summary = "임시 음향기기 추가", description = "사용자가 자신의 음향기기가 본 서비스의 DB에 없어 등록하지 못할경우 사용.")
     public ResponseEntity<SuccessCode> createTempGear(
-            @RequestBody @Valid TempGearRequest req ) {
+            @RequestBody @Valid TempGearRequest req,
+            @RequestPart("image")MultipartFile images
+            ) {
         gearCommandService.saveTempGear(req);
 
         return ResponseEntity.ok(SuccessCode.CREATE_SUCCESS);

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/controller/GearCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/controller/GearCommandController.java
@@ -1,4 +1,66 @@
 package com.notfound.lpickbackend.servicedata.command.application.controller;
 
+import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common.exception.ErrorCode;
+import com.notfound.lpickbackend.common.exception.SuccessCode;
+import com.notfound.lpickbackend.servicedata.command.application.domain.dto.TempGearRequest;
+import com.notfound.lpickbackend.servicedata.command.application.service.GearCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "음향기기 컨트롤러", description = "'임시' 음향기기 추가/수정/삭제 가능.")
+
 public class GearCommandController {
+
+    private final GearCommandService gearCommandService;
+
+    @PostMapping("/gear/temp-gear")
+    @Operation(summary = "임시 음향기기 추가", description = "사용자가 자신의 음향기기가 본 서비스의 DB에 없어 등록하지 못할경우 사용.")
+    public ResponseEntity<SuccessCode> createTempGear(
+            @RequestBody @Valid TempGearRequest req ) {
+        gearCommandService.saveTempGear(req);
+
+        return ResponseEntity.ok(SuccessCode.CREATE_SUCCESS);
+    }
+
+    @PatchMapping("/gear/{gear-id}/update-info")
+    @Operation(summary = "음향기기 정보 수정 및 승인", description = "[관리자] 잘못 설정된 음향기기의 정보 수정 목적. 임시 음향기기를 수정할 경우 approve 한 것으로 간주.")
+    public ResponseEntity<SuccessCode> updateGearInfo(
+            @PathVariable("gear-id") String tempGearId,
+            @RequestBody @Valid TempGearRequest req ) {
+
+        gearCommandService.updateGear(req, tempGearId);
+
+        return ResponseEntity.ok(SuccessCode.GEAR_UPDATE_SUCESS);
+    }
+
+
+    // 추후 관리자만 사용 가능한 기능으로 설정하기
+    @PatchMapping("/gear/temp-gear/{temp-gear-id}/approve")
+    @Operation(summary = "임시 음향기기 승인", description = "[관리자] 사용자가 임시로 설정해둔 음향기기를 승인.")
+    public ResponseEntity<SuccessCode> approveTempGear(
+            @PathVariable("temp-gear-id") String tempGearId
+    ) {
+        gearCommandService.approveTempGear(tempGearId);
+
+        return ResponseEntity.ok(SuccessCode.TEMP_GEAR_APPROVE_SUCESS);
+    }
+
+    // 추후 관리자만 사용 가능한 기능으로 설정하기
+    @DeleteMapping("/gear/{gear-id}")
+    @Operation(summary = "음향기기 삭제", description = "[관리자] 음향기기를 DB에서 삭제. 잘못 승인된 음향기기 등 제거 목적")
+    public ResponseEntity<SuccessCode> deleteTempGear(
+            @PathVariable("gear-id") String tempGearId
+    ) {
+        gearCommandService.deleteById(tempGearId);
+
+        return ResponseEntity.ok(SuccessCode.TEMP_GEAR_APPROVE_SUCESS);
+    }
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Album.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Album.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.servicedata.command.domain;
+package com.notfound.lpickbackend.servicedata.command.application.domain;
 
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
 import jakarta.persistence.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/AlbumGenre.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/AlbumGenre.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.servicedata.command.domain;
+package com.notfound.lpickbackend.servicedata.command.application.domain;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Artist.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Artist.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.servicedata.command.domain;
+package com.notfound.lpickbackend.servicedata.command.application.domain;
 
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
 import jakarta.persistence.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/ArtistAlbum.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/ArtistAlbum.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.servicedata.command.domain;
+package com.notfound.lpickbackend.servicedata.command.application.domain;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Gear.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Gear.java
@@ -1,20 +1,20 @@
 package com.notfound.lpickbackend.servicedata.command.application.domain;
 
+import com.notfound.lpickbackend.common._super.BaseEntity;
+import com.notfound.lpickbackend.servicedata.command.application.domain.dto.TempGearRequest;
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
 @Entity
 @Table(name = "gear")
-public class Gear {
-    @Id
-    @Column(name = "eq_id", nullable = false, length = 40)
-    private String eqId;
+public class Gear extends BaseEntity {
 
     @Column(name = "name", nullable = false, length = 50)
     private String name;
@@ -25,6 +25,9 @@ public class Gear {
     @Column(name = "brand", length = 50)
     private String brand;
 
+    @Column(name = "is_temp", nullable = false)
+    private boolean isTemp;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "eq_class", nullable = false)
     private GearClass eqClass;
@@ -32,5 +35,16 @@ public class Gear {
     @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "wiki_id")
     private WikiPage wiki;
+
+    // isTemp True -> False로 변환. 사용자가 임시로 작성해뒀던 Gear를 수정없이 허가한다.
+    public void approveTempGear() {
+        this.isTemp = false;
+    }
+
+    public void updateTempGear(TempGearRequest req, GearClass eqClass) {
+        this.modelName = req.getModelName();
+        this.eqClass = eqClass;
+        this.brand = req.getBrand();
+    }
 
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Gear.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Gear.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.servicedata.command.domain;
+package com.notfound.lpickbackend.servicedata.command.application.domain;
 
 import com.notfound.lpickbackend.wiki.command.application.domain.WikiPage;
 import jakarta.persistence.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/GearClass.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/GearClass.java
@@ -1,5 +1,6 @@
 package com.notfound.lpickbackend.servicedata.command.application.domain;
 
+import com.notfound.lpickbackend.common._super.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -14,10 +15,10 @@ import lombok.*;
 @Entity
 @Table(name = "gear_class")
 public class GearClass {
-    @Id
-    @Column(name = "class_id", nullable = false, length = 40)
-    private String classId;
 
+    // GearClass는 enum을 그대로 나타내는 목적의 엔티티.
+    // 즉, 별도의 id 둘 필요 없이 className == PK로 사용하면 끝.
+    @Id
     @Column(name = "class_name", length = 50)
     private String className;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/GearClass.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/GearClass.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.servicedata.command.domain;
+package com.notfound.lpickbackend.servicedata.command.application.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Genre.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/Genre.java
@@ -1,4 +1,4 @@
-package com.notfound.lpickbackend.servicedata.command.domain;
+package com.notfound.lpickbackend.servicedata.command.application.domain;
 
 import com.notfound.lpickbackend.AUTO_ENTITIES.TOOL.IdPrefixUtil;
 import jakarta.persistence.*;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/ServiceDataImage.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/ServiceDataImage.java
@@ -1,0 +1,24 @@
+package com.notfound.lpickbackend.servicedata.command.application.domain;
+
+import com.notfound.lpickbackend.common._super.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Entity
+@Table(name = "service_data_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ServiceDataImage extends BaseEntity {
+
+
+    @Column(name = "src", nullable = false, length = 255)
+    private String src;
+
+    @Column(name = "type", nullable = false, length = 10)
+    private String type;
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/dto/TempGearRequest.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/domain/dto/TempGearRequest.java
@@ -1,0 +1,25 @@
+package com.notfound.lpickbackend.servicedata.command.application.domain.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+// create, update 모두 사용
+@Getter
+@AllArgsConstructor
+@Builder
+public class TempGearRequest {
+    @NotEmpty
+    private String modelName;
+
+    @NotEmpty
+    @Pattern(
+            regexp = "SPEAKER|HEADPHONE|TURNTABLE",
+            message = "gearCategory는 SPEAKER, HEADPHONE, TURNTABLE 중 하나여야 합니다."
+    )
+    private String gearClass;
+
+    private String brand; // 브랜드는 미상일 수 있음
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/repository/GearCommandRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/repository/GearCommandRepository.java
@@ -1,0 +1,9 @@
+package com.notfound.lpickbackend.servicedata.command.application.repository;
+
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GearCommandRepository extends JpaRepository<Gear, String> {
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/service/GearCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/service/GearCommandService.java
@@ -1,0 +1,81 @@
+package com.notfound.lpickbackend.servicedata.command.application.service;
+
+import com.notfound.lpickbackend.common._super.BaseCommandService;
+import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common.exception.ErrorCode;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
+import com.notfound.lpickbackend.servicedata.command.application.domain.dto.TempGearRequest;
+import com.notfound.lpickbackend.servicedata.command.application.repository.GearCommandRepository;
+import com.notfound.lpickbackend.servicedata.query.service.GearClassQueryService;
+import com.notfound.lpickbackend.servicedata.query.service.GearQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GearCommandService extends BaseCommandService<Gear, String> {
+
+    private final GearCommandRepository gearCommandRepository;
+
+    private final GearQueryService gearQueryService;
+
+    private final GearClassQueryService gearClassQueryService;
+
+    @Override
+    public Gear saveEntity(Gear entity) {
+        return super.saveEntity(entity);
+    }
+
+    // 관리자만 사용가능하게 추후 수정
+    @Override
+    public void deleteById(String id) {
+        super.deleteById(id);
+    }
+
+    @Transactional
+    public void saveTempGear(TempGearRequest request) {
+        Gear gear = Gear.builder()
+                .id(null)
+                .name(null) // name이 필드 제거 여부 결정 필요? 모델명 말고 다른걸 name이라고 부를만한 정보가 있는가?
+                .modelName(request.getModelName())
+                .brand(request.getBrand())
+                .eqClass(gearClassQueryService.findByClassName(request.getGearClass()))
+                .isTemp(true)
+                .build();
+
+        saveEntity(gear);
+    }
+
+
+    // 관리자만 사용가능하게 추후 수정
+    @Transactional
+    public void updateGear(TempGearRequest req, String gearId) {
+        Gear targetGear = gearQueryService.findById(gearId);
+
+        targetGear.updateTempGear(req, gearClassQueryService.findByClassName(req.getGearClass()));
+        if(targetGear.isTemp()) targetGear.approveTempGear();
+
+        saveEntity(targetGear);
+    }
+
+    // 관리자만 사용가능하게 추후 수정
+    @Transactional
+    public void approveTempGear(String tempGearId) {
+        Gear targetTempGear = gearQueryService.findById(tempGearId);
+
+        // tempGear가 아닌 경우
+        if(!targetTempGear.isTemp()) throw new CustomException(ErrorCode.IS_NOT_TEMP_GEAR);
+
+        targetTempGear.approveTempGear();
+
+        saveEntity(targetTempGear);
+
+    }
+
+    @Override
+    protected JpaRepository<Gear, String> getRepository() {
+        return gearCommandRepository;
+    }
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/service/GearCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/command/application/service/GearCommandService.java
@@ -3,6 +3,7 @@ package com.notfound.lpickbackend.servicedata.command.application.service;
 import com.notfound.lpickbackend.common._super.BaseCommandService;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
+import com.notfound.lpickbackend.common.s3.service.S3Uploader;
 import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import com.notfound.lpickbackend.servicedata.command.application.domain.dto.TempGearRequest;
 import com.notfound.lpickbackend.servicedata.command.application.repository.GearCommandRepository;
@@ -22,6 +23,8 @@ public class GearCommandService extends BaseCommandService<Gear, String> {
     private final GearQueryService gearQueryService;
 
     private final GearClassQueryService gearClassQueryService;
+
+    private final S3Uploader s3Uploader;
 
     @Override
     public Gear saveEntity(Gear entity) {

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/AlbumQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/AlbumQueryRepository.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.servicedata.query.repository;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/ArtistQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/ArtistQueryRepository.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.servicedata.query.repository;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Artist;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Artist;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/GearClassQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/GearClassQueryRepository.java
@@ -1,0 +1,9 @@
+package com.notfound.lpickbackend.servicedata.query.repository;
+
+import com.notfound.lpickbackend.servicedata.command.application.domain.GearClass;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GearClassQueryRepository extends JpaRepository<GearClass, String> {
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/GearQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/GearQueryRepository.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.servicedata.query.repository;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Gear;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/GenreQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/repository/GenreQueryRepository.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.servicedata.query.repository;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Genre;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Genre;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GenreQueryRepository extends JpaRepository<Genre, String> {

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/AlbumQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/AlbumQueryService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.servicedata.query.service;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.servicedata.query.repository.AlbumQueryRepository;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GearClassQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GearClassQueryService.java
@@ -1,0 +1,25 @@
+package com.notfound.lpickbackend.servicedata.query.service;
+
+import com.notfound.lpickbackend.common._super.BaseQueryService;
+import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common.exception.ErrorCode;
+import com.notfound.lpickbackend.servicedata.command.application.domain.GearClass;
+import com.notfound.lpickbackend.servicedata.query.repository.GearClassQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Service;
+
+
+// GearClass 엔티티는 기존과 다른 양식을 취하므로 BaseEntity, BaseQueryService 활용하지 않음.
+@Service
+@RequiredArgsConstructor
+public class GearClassQueryService {
+
+    private final GearClassQueryRepository gearClassQueryRepository;
+
+    // GearClass는 name 또한 기능
+    public GearClass findByClassName(String className) {
+        return gearClassQueryRepository.findById(className)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GEAR));
+    }
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GearQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GearQueryService.java
@@ -2,7 +2,7 @@ package com.notfound.lpickbackend.servicedata.query.service;
 
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
-import com.notfound.lpickbackend.servicedata.command.domain.Gear;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import com.notfound.lpickbackend.servicedata.query.repository.GearQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GearQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GearQueryService.java
@@ -1,21 +1,39 @@
 package com.notfound.lpickbackend.servicedata.query.service;
 
-import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common._super.BaseQueryService;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import com.notfound.lpickbackend.servicedata.query.repository.GearQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class GearQueryService {
+public class GearQueryService extends BaseQueryService<Gear, String> {
     private final GearQueryRepository gearQueryRepository;
 
-    @Transactional(readOnly = true)
-    public Gear findById(String gearId) {
-        return gearQueryRepository.findById(gearId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GEAR));
+    @Override
+    protected JpaRepository<Gear, String> getRepository() {
+        return gearQueryRepository;
+    }
+
+    @Override
+    protected ErrorCode notFoundErrorCode() {
+        return ErrorCode.NOT_FOUND_GEAR;
+    }
+    
+    // 이 사이에 개발자가 추가하는 메소드가 오게끔 하기
+    
+    @Override
+    public Gear findById(String id) {
+        return super.findById(id);
+    }
+
+    @Override
+    public List<Gear> findAll() {
+        return super.findAll();
     }
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GenreQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/servicedata/query/service/GenreQueryService.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.servicedata.query.service;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Genre;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Genre;
 import com.notfound.lpickbackend.servicedata.query.repository.GenreQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/controller/UserGearCommandController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/controller/UserGearCommandController.java
@@ -3,10 +3,13 @@ package com.notfound.lpickbackend.userinfo.command.application.controller;
 import com.notfound.lpickbackend.security.util.UserInfoUtil;
 import com.notfound.lpickbackend.userinfo.command.application.dto.domaindto.request.UserGearPostRequest;
 import com.notfound.lpickbackend.userinfo.command.application.service.UserGearCommandService;
+import com.notfound.lpickbackend.userinfo.query.dto.response.FavoriteToggleStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -24,11 +27,17 @@ public class UserGearCommandController {
         userGearCommandService.createNewUserGear(UserInfoUtil.getOAuthId(), userGearPostRequest);
     }
 
-//    @PatchMapping("/user/gear")
-//    public void patchUserGear() {
-//
-//    }
-
+    @PatchMapping("/user/gear/{userGearId}/favorite-toggle")
+    @Operation(summary = "사용자 소유 음향기기에 대한 favorite 토글", description = "사용자가 자신이 소유한 음향기기에 대해 favorite 토글을 진행하여 favorite 리스트에 추가가능. favorite 리스트는 마이페이지에서 별도 표기됨. 요청 시 마다 업데이트 결과 boolean 값을 전달해주므로, 해당 값을 기반으로 프론트측 업데이트 진행.")
+    public ResponseEntity<FavoriteToggleStatus> toggleUserGearFavorite(
+            @PathVariable("userGearId") String userGearId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(userGearCommandService.patchUserGearFavoriteToggle(
+                        UserInfoUtil.getOAuthId(),
+                        userGearId
+                )
+        );
+    }
 
     @DeleteMapping("/user/gear/{userGearId}")
     @Operation(summary = "사용자 음향기기 제거", description = "사용자의 음향기기를 제거.")

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserAlbum.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserAlbum.java
@@ -1,6 +1,6 @@
 package com.notfound.lpickbackend.userinfo.command.application.domain.entity;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
 import com.notfound.lpickbackend.AUTO_ENTITIES.TOOL.IdPrefixUtil;
 import jakarta.persistence.*;
 import lombok.Builder;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserGear.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserGear.java
@@ -1,8 +1,7 @@
 package com.notfound.lpickbackend.userinfo.command.application.domain.entity;
 
 import com.notfound.lpickbackend.AUTO_ENTITIES.TOOL.IdPrefixUtil;
-import com.notfound.lpickbackend.servicedata.command.domain.Gear;
-import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserGear.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserGear.java
@@ -28,6 +28,9 @@ public class UserGear {
     @Column(name = "user_gear_id", nullable = false, length = 40)
     private String userGearId;
 
+    @Column(name = "is_favorite", nullable = false)
+    private boolean isFavorite;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "oauth_id", nullable = false)
     private UserInfo oauth;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/inherenceENUM/GearClass.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/inherenceENUM/GearClass.java
@@ -2,5 +2,5 @@ package com.notfound.lpickbackend.userinfo.command.application.domain.inherenceE
 
 
 public enum GearClass {
-    SPEAKER, HEADPHONE, TURNTABLE;
+    SPEAKER, HEADPHONE, TURNTABLE, AMP;
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/inherenceENUM/GearClass.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/inherenceENUM/GearClass.java
@@ -3,4 +3,6 @@ package com.notfound.lpickbackend.userinfo.command.application.domain.inherenceE
 
 public enum GearClass {
     SPEAKER, HEADPHONE, TURNTABLE, AMP;
+
+
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserAlbumCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserAlbumCommandService.java
@@ -3,7 +3,7 @@ package com.notfound.lpickbackend.userinfo.command.application.service;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.common.s3.service.S3Uploader;
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserAlbum;
 import com.notfound.lpickbackend.servicedata.query.service.AlbumQueryService;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandService.java
@@ -48,6 +48,7 @@ public class UserGearCommandService {
         userGearCommandRepository.delete(userGear);
     }
 
+    @Transactional
     public FavoriteToggleStatus patchUserGearFavoriteToggle(String oAuthId, String userGearId) {
         // userGear는 분류별로 1개의 favorite만 설정할 수 있다
 
@@ -61,7 +62,7 @@ public class UserGearCommandService {
                 );
         
         // 분류 카운트가 1개 이상이고, 토글 결과가 true인 경우 에러 발생
-        if(classFavoriteCount >= 1 && !target.isFavorite())
+        if(classFavoriteCount >= 1L && !target.isFavorite())
             throw new CustomException(ErrorCode.ALREADY_FULL_FAVORITE_GEAR);
 
         target.setFavorite(!target.isFavorite());
@@ -72,7 +73,7 @@ public class UserGearCommandService {
     }
 
     /** pathvariable 기반 ID로 가져온 엔티티와 현재 security 기반하에 사용자가 동일한지 검증  */
-    private void checkUserOwnedGear(UserGear userGear, String oAuthId) {
+    protected void checkUserOwnedGear(UserGear userGear, String oAuthId) {
         if(!userGear.getOauth().getOauthId().equals(oAuthId)) throw new CustomException(ErrorCode.FORBIDDEN_RESOURCE_ACCESS);
 
     }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandService.java
@@ -2,10 +2,14 @@ package com.notfound.lpickbackend.userinfo.command.application.service;
 
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
+import com.notfound.lpickbackend.common.util.EnumUtils;
 import com.notfound.lpickbackend.servicedata.query.service.GearQueryService;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserGear;
+import com.notfound.lpickbackend.userinfo.command.application.domain.inherenceENUM.GearClass;
 import com.notfound.lpickbackend.userinfo.command.application.dto.domaindto.request.UserGearPostRequest;
 import com.notfound.lpickbackend.userinfo.command.repository.UserGearCommandRepository;
+import com.notfound.lpickbackend.userinfo.query.dto.response.FavoriteToggleStatus;
+import com.notfound.lpickbackend.userinfo.query.dto.response.usergear.GearInfoResponse;
 import com.notfound.lpickbackend.userinfo.query.service.UserGearQueryService;
 import com.notfound.lpickbackend.userinfo.query.service.UserInfoQueryService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +23,9 @@ public class UserGearCommandService {
     private final UserGearQueryService userGearQueryService;
     private final GearQueryService gearQueryService;
     private final UserInfoQueryService userInfoQueryService;
+
+    // userGear는 분류별로 제한 없이 설정할 수 있다
+    // userGear는 favorite toggle이 존재하며, 분류 별로 1개씩의 favorite만 설정해 둘 수 있다
 
     @Transactional
     public void createNewUserGear(String oAuthId, UserGearPostRequest userGearPostRequest) {
@@ -36,8 +43,37 @@ public class UserGearCommandService {
         UserGear userGear = userGearQueryService.findById(userGearId);
 
         // 사용자 소유의 userGear가 맞는지 확인
-        if(!userGear.getOauth().getOauthId().equals(oAuthId)) throw new CustomException(ErrorCode.FORBIDDEN_RESOURCE_ACCESS);
+        checkUserOwnedGear(userGear, oAuthId);
 
         userGearCommandRepository.delete(userGear);
+    }
+
+    public FavoriteToggleStatus patchUserGearFavoriteToggle(String oAuthId, String userGearId) {
+        // userGear는 분류별로 1개의 favorite만 설정할 수 있다
+
+        UserGear target = userGearQueryService.findGearDetailInfoById(userGearId);
+
+        checkUserOwnedGear(target, oAuthId);
+
+        long classFavoriteCount =
+                userGearQueryService.countUserGearFavoriteByClassName(oAuthId,
+                        target.getEq().getEqClass().getClassName()
+                );
+        
+        // 분류 카운트가 1개 이상이고, 토글 결과가 true인 경우 에러 발생
+        if(classFavoriteCount >= 1 && !target.isFavorite())
+            throw new CustomException(ErrorCode.ALREADY_FULL_FAVORITE_GEAR);
+
+        target.setFavorite(!target.isFavorite());
+
+        userGearCommandRepository.save(target);
+
+        return new FavoriteToggleStatus(target.isFavorite());
+    }
+
+    /** pathvariable 기반 ID로 가져온 엔티티와 현재 security 기반하에 사용자가 동일한지 검증  */
+    private void checkUserOwnedGear(UserGear userGear, String oAuthId) {
+        if(!userGear.getOauth().getOauthId().equals(oAuthId)) throw new CustomException(ErrorCode.FORBIDDEN_RESOURCE_ACCESS);
+
     }
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/repository/UserSettingCommandRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/repository/UserSettingCommandRepository.java
@@ -2,6 +2,8 @@ package com.notfound.lpickbackend.userinfo.command.repository;
 
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserSettingCommandRepository extends JpaRepository<UserSetting, String> {
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/dto/response/usergear/GearInfoResponse.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/dto/response/usergear/GearInfoResponse.java
@@ -9,15 +9,17 @@ import lombok.Getter;
 public class GearInfoResponse {
     private String id;
     private String name;
+    private boolean isFavorite;
     private String modelName;
     private String brand;
     private GearClass gearClass;
     private String wikiId;
     
     // 쿼리로 구현한 GearInfoResponse의 gearClass를 String으로 전달받아 Java 단에서 Enum으로 변경하기위한 목적의 별도 생성자
-    public GearInfoResponse(String id, String name, String modelName, String brand, String gearClass, String wikiId) {
+    public GearInfoResponse(String id, String name, boolean isFavorite, String modelName, String brand, String gearClass, String wikiId) {
         this.id = id;
         this.name = name;
+        this.isFavorite = isFavorite;
         this.modelName = modelName;
         this.brand = brand;
         this.gearClass = GearClass.valueOf(gearClass.toUpperCase());
@@ -25,9 +27,11 @@ public class GearInfoResponse {
     }
     
     // AllArgsConstructor - 빌더 사용 목적
-    public GearInfoResponse(String id, String name, String modelName, String brand, GearClass gearClass, String wikiId) {
+
+    public GearInfoResponse(String id, String name, boolean isFavorite, String modelName, String brand, GearClass gearClass, String wikiId) {
         this.id = id;
         this.name = name;
+        this.isFavorite = isFavorite;
         this.modelName = modelName;
         this.brand = brand;
         this.gearClass = gearClass;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserGearQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserGearQueryRepository.java
@@ -2,20 +2,45 @@ package com.notfound.lpickbackend.userinfo.query.repository;
 
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserGear;
 import com.notfound.lpickbackend.userinfo.query.dto.response.usergear.GearInfoResponse;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserGearQueryRepository extends JpaRepository<UserGear, String> {
+    // GearCollection == 사용자에게 반환하기위한 목적의 내역 반환
+    // GearDetail == 서버 내에서 각 기능에 활용하기위한 목적의 N+1 방지 목적 EntityGraph 적용 엔티티 반환
+
 
     @Query("""
         SELECT DISTINCT new com.notfound.lpickbackend.userinfo.query.dto.response.usergear.GearInfoResponse(
             ug.userGearId,
             g.name,
+            ug.isFavorite,
+            g.modelName,
+            g.brand,
+            eq.className,
+            g.wiki.wikiId
+        )
+        FROM UserGear ug
+        JOIN ug.eq g
+        JOIN g.eqClass eq
+        WHERE ug.userGearId = :gearId
+    """)
+    Optional<GearInfoResponse> findGearCollectionById(
+            @Param("gearId") String userGearId
+    );
+
+    @Query("""
+        SELECT DISTINCT new com.notfound.lpickbackend.userinfo.query.dto.response.usergear.GearInfoResponse(
+            ug.userGearId,
+            g.name,
+            ug.isFavorite,
             g.modelName,
             g.brand,
             eq.className,
@@ -28,5 +53,35 @@ public interface UserGearQueryRepository extends JpaRepository<UserGear, String>
     """)
     List<GearInfoResponse> findAllGearCollectionByUserId(
             @Param("oauthId") String oauthId
+    );
+
+    // 메소드명 명시적 작성 위해 쿼리구문으로 작성.
+    /** EntityGraph 대상 : eq, eq.class || 음향기기 및 음향기기 클래스 명칭까지 한번에 확인 필요한(Detail) 엔티티 필요시 사용 요망.*/
+    @Query("""
+      SELECT ug
+      FROM   UserGear ug
+        JOIN FETCH ug.eq g
+        JOIN FETCH g.eqClass c
+      WHERE  ug.userGearId = :userGearId
+    """)
+    @EntityGraph(attributePaths = {"eq", "eq.eqClass"})
+    Optional<UserGear> findGearDetailByIdWithEqAndEqClass(String userGearId);
+
+    /**
+     * 주어진 oauthId 사용자가 즐겨찾기(isFavorite=true)한 기어 중,
+     * eq.eqClass.className이 파라미터와 동일한 것의 개수를 반환
+     */
+    @Query("""
+      SELECT COUNT(ug)
+      FROM   UserGear ug
+      JOIN   ug.eq g
+      JOIN   g.eqClass eq
+      WHERE  eq.className = :className
+        AND  ug.isFavorite = TRUE
+        AND  ug.oauth.oauthId = :oauthId
+    """)
+    long countFavoritesByOauthIdAndClassName(
+            @Param("oauthId")   String oauthId,
+            @Param("className") String className
     );
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserSettingQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserSettingQueryRepository.java
@@ -2,6 +2,8 @@ package com.notfound.lpickbackend.userinfo.query.repository;
 
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserSettingQueryRepository extends JpaRepository<UserSetting, String> {
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserGearQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserGearQueryService.java
@@ -62,7 +62,7 @@ public class UserGearQueryService {
                 .build();
     }
 
-    /** UserGear는 User - Gear 간의 매핑 여부 및 좋아요 여부만을 확인하므로, UserGear의 분류 등을 확인하기 위해서는 해당 기능 사용 요망. */
+    /** UserGear는 User - Gear 간의 매핑 여부 및 좋아요 여부만을 확인하므로, UserGear의 분류 등을 확인하기 위해서는 해당 기능 사용 요망. EntityGraph 적용된 엔티티 반환 */
     public UserGear findGearDetailInfoById(String userGearId) {
         return userGearQueryRepository.findGearDetailByIdWithEqAndEqClass(userGearId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER_GEAR));

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserGearQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserGearQueryService.java
@@ -5,12 +5,12 @@ import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserGear;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserSetting;
-import com.notfound.lpickbackend.userinfo.command.application.domain.inherenceENUM.GearClass;
 import com.notfound.lpickbackend.userinfo.query.dto.response.usergear.GearInfoResponse;
 import com.notfound.lpickbackend.userinfo.query.dto.response.usergear.UserGearCollectionResponse;
 import com.notfound.lpickbackend.userinfo.query.repository.UserGearQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -62,8 +62,21 @@ public class UserGearQueryService {
                 .build();
     }
 
+    /** UserGear는 User - Gear 간의 매핑 여부 및 좋아요 여부만을 확인하므로, UserGear의 분류 등을 확인하기 위해서는 해당 기능 사용 요망. */
+    public UserGear findGearDetailInfoById(String userGearId) {
+        return userGearQueryRepository.findGearDetailByIdWithEqAndEqClass(userGearId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER_GEAR));
+    }
+
+
     public UserGear findById(String id) {
         return userGearQueryRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER_GEAR));
+    }
+
+    /** 어떤 사용자가 특정 ClassName의 UserGear를 얼마나 Favorite True 했는지 카운트하는 목적의 메소드 */
+    @Transactional(readOnly = true)
+    public long countUserGearFavoriteByClassName(String oAuthId, String className) {
+        return userGearQueryRepository.countByOauth_OauthIdAndIsFavoriteTrue(oAuthId, className);
     }
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserGearQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserGearQueryService.java
@@ -77,6 +77,6 @@ public class UserGearQueryService {
     /** 어떤 사용자가 특정 ClassName의 UserGear를 얼마나 Favorite True 했는지 카운트하는 목적의 메소드 */
     @Transactional(readOnly = true)
     public long countUserGearFavoriteByClassName(String oAuthId, String className) {
-        return userGearQueryRepository.countByOauth_OauthIdAndIsFavoriteTrue(oAuthId, className);
+        return userGearQueryRepository.countFavoritesByOauthIdAndClassName(oAuthId, className);
     }
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserInfoQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserInfoQueryService.java
@@ -17,6 +17,4 @@ public class UserInfoQueryService {
         return userInfoQueryRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTHENTICATION_FAILED));
     }
-
-
 }

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/WikiPage.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/domain/WikiPage.java
@@ -1,9 +1,9 @@
 package com.notfound.lpickbackend.wiki.command.application.domain;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
-import com.notfound.lpickbackend.servicedata.command.domain.Artist;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Artist;
 import com.notfound.lpickbackend.AUTO_ENTITIES.Debate;
-import com.notfound.lpickbackend.servicedata.command.domain.Gear;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import com.notfound.lpickbackend.AUTO_ENTITIES.TOOL.IdPrefixUtil;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandService.java
@@ -1,9 +1,9 @@
 package com.notfound.lpickbackend.wiki.command.application.service;
 
 
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
-import com.notfound.lpickbackend.servicedata.command.domain.Artist;
-import com.notfound.lpickbackend.servicedata.command.domain.Gear;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Artist;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
 import com.notfound.lpickbackend.userinfo.query.service.UserInfoQueryService;
 import com.notfound.lpickbackend.wiki.command.application.domain.PageRevision;

--- a/lpick-backend/src/main/resources/ID-PREFIX.yml
+++ b/lpick-backend/src/main/resources/ID-PREFIX.yml
@@ -24,3 +24,5 @@ UserGear : UGR
 UserInfo : U
 WikiBookmark : WPB
 WikiPage : WP
+CommunityImage : CIM
+ServiceDataImage : DIM

--- a/lpick-backend/src/main/resources/data.sql
+++ b/lpick-backend/src/main/resources/data.sql
@@ -29,11 +29,14 @@ INSERT INTO page_revision(revision_id, content, revision_number, created_at, wik
 INSERT INTO page_revision(revision_id, content, revision_number, created_at, wiki_id, oauth_id) VALUES
     ('revision-1', '위키내용입니다.', 'r1', '2025-06-03 12:20:23', 'wiki-1', '1') ON CONFLICT (revision_id) DO NOTHING;
 
-
+-- # service_data
 -- Album 기입
 INSERT INTO album(album_id, name, profile, release_date, release_country, label, wiki_id) VALUES
     ('album-1', '앨범명칭', null, '2025-06-05 00:21:12', 'KR', '으랏차차레이블', null) ON CONFLICT (album_id) DO NOTHING;
 
+-- Gear 기입
+INSERT INTO gear(id, name, model_name, brand, eq_class, wiki_id) VALUES
+    ('gear-1', '명칭', 'dp-300f', 'Denon', 'TURNTABLE', null) ON CONFLICT (id) DO NOTHING;
 
 
 -- Role 기입

--- a/lpick-backend/src/main/resources/schema.sql
+++ b/lpick-backend/src/main/resources/schema.sql
@@ -203,6 +203,7 @@ CREATE TABLE IF NOT EXISTS gear (
                       name	varchar(50)		NOT NULL,
                       model_name	varchar(100)		NULL,
                       brand	varchar(50)		NULL,
+                      is_temp  boolean NOT NULL DEFAULT FALSE,
                       eq_class	varchar(50)		NOT NULL,
                       wiki_id	varchar(40)		NULL
 );
@@ -214,6 +215,20 @@ CREATE TABLE IF NOT EXISTS report (
                         report_explain	text		NOT NULL,
                         created_at	timestamp		NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS service_data_image (
+                        id	varchar(40)		NOT NULL,
+                        src varchar(255)   NOT NULL,
+                        type varchar(10)   NOT NULL
+
+);
+
+CREATE TABLE IF NOT EXISTS community_image (
+                        id	varchar(40)		NOT NULL,
+                        src varchar(255)   NOT NULL,
+                        type varchar(10)   NOT NULL
+);
+
 -- ==============================================================
 -- 2) PK 제약조건: DROP IF EXISTS … CASCADE 후 ADD
 -- ==============================================================
@@ -357,6 +372,16 @@ ALTER TABLE report
     DROP CONSTRAINT IF EXISTS PK_REPORT CASCADE;
 ALTER TABLE report
     ADD CONSTRAINT PK_REPORT PRIMARY KEY (report_id);
+
+ALTER TABLE service_data_image
+    DROP CONSTRAINT IF EXISTS PK_SERVICE_DATA_IMAGE CASCADE;
+ALTER TABLE service_data_image
+    ADD CONSTRAINT PK_SERVICE_DATA_IMAGE PRIMARY KEY (id);
+
+ALTER TABLE community_image
+    DROP CONSTRAINT IF EXISTS PK_COMMUNITY_IMAGE CASCADE;
+ALTER TABLE community_image
+    ADD CONSTRAINT PK_COMMUNITY_IMAGE PRIMARY KEY (id);
 
 
 -- ==============================================================

--- a/lpick-backend/src/main/resources/schema.sql
+++ b/lpick-backend/src/main/resources/schema.sql
@@ -175,8 +175,7 @@ CREATE TABLE IF NOT EXISTS review (
 );
 
 CREATE TABLE IF NOT EXISTS gear_class (
-                            class_id	varchar(40)		NOT NULL,
-                            class_name	varchar(50)		NULL
+                            class_name	varchar(40)		NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS debate (
@@ -199,7 +198,7 @@ CREATE TABLE IF NOT EXISTS article_like (
 );
 
 CREATE TABLE IF NOT EXISTS gear (
-                      eq_id	varchar(40)		NOT NULL,
+                      id	varchar(40)		NOT NULL,
                       name	varchar(50)		NOT NULL,
                       model_name	varchar(100)		NULL,
                       brand	varchar(50)		NULL,
@@ -346,7 +345,7 @@ ALTER TABLE review
 ALTER TABLE gear_class
     DROP CONSTRAINT IF EXISTS PK_GEAR_CLASS CASCADE;
 ALTER TABLE gear_class
-    ADD CONSTRAINT PK_GEAR_CLASS PRIMARY KEY (class_id);
+    ADD CONSTRAINT PK_GEAR_CLASS PRIMARY KEY (class_name);
 
 ALTER TABLE debate
     DROP CONSTRAINT IF EXISTS PK_DEBATE CASCADE;
@@ -366,7 +365,7 @@ ALTER TABLE article_like
 ALTER TABLE gear
     DROP CONSTRAINT IF EXISTS PK_GEAR CASCADE;
 ALTER TABLE gear
-    ADD CONSTRAINT PK_GEAR PRIMARY KEY (eq_id);
+    ADD CONSTRAINT PK_GEAR PRIMARY KEY (id);
 
 ALTER TABLE report
     DROP CONSTRAINT IF EXISTS PK_REPORT CASCADE;
@@ -404,7 +403,7 @@ ALTER TABLE user_gear
     DROP CONSTRAINT IF EXISTS FK_gear_TO_user_gear_1 CASCADE;
 ALTER TABLE user_gear
     ADD CONSTRAINT FK_gear_TO_user_gear_1
-        FOREIGN KEY (eq_id) REFERENCES gear (eq_id);
+        FOREIGN KEY (eq_id) REFERENCES gear (id);
 
 ALTER TABLE page_revision
     DROP CONSTRAINT IF EXISTS FK_wiki_page_TO_page_revision_1 CASCADE;
@@ -620,7 +619,7 @@ ALTER TABLE gear
     DROP CONSTRAINT IF EXISTS FK_gear_class_TO_gear_1 CASCADE;
 ALTER TABLE gear
     ADD CONSTRAINT FK_gear_class_TO_gear_1
-        FOREIGN KEY (eq_class)REFERENCES gear_class (class_id);
+        FOREIGN KEY (eq_class)REFERENCES gear_class (class_name);
 
 ALTER TABLE gear
     DROP CONSTRAINT IF EXISTS FK_wiki_page_TO_gear_1 CASCADE;

--- a/lpick-backend/src/main/resources/schema.sql
+++ b/lpick-backend/src/main/resources/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS genre (
 
 CREATE TABLE IF NOT EXISTS user_gear (
                            user_gear_id	varchar(40)		NOT NULL,
+                           is_favorite boolean      NOT NULL DEFAULT FALSE,
                            oauth_id	varchar(40)		NOT NULL,
                            eq_id	varchar(40)		NOT NULL
 );

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/common/_super/BaseCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/common/_super/BaseCommandServiceTest.java
@@ -1,0 +1,64 @@
+package com.notfound.lpickbackend.common._super;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class BaseCommandServiceTest {
+
+    // 1) 테스트용 엔티티: ID만 갖는 아주 단순한 자식 클래스
+    static class DummyEntity extends BaseEntity {
+        public DummyEntity(String id) { setId(id); }
+        public void setId(String id) { super.setId(id); }
+    }
+
+    // 2) BaseCommandService 를 구현한 아주 단순한 서브클래스
+    static class DummyService extends BaseCommandService<DummyEntity, String> {
+        private final JpaRepository<DummyEntity, String> repo;
+        public DummyService(JpaRepository<DummyEntity, String> repo) {
+            this.repo = repo;
+        }
+        @Override protected JpaRepository<DummyEntity, String> getRepository() {
+            return repo;
+        }
+    }
+
+    @Mock
+    private JpaRepository<DummyEntity, String> mockRepo;
+
+    private DummyService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DummyService(mockRepo);
+    }
+
+    @Test
+    void saveEntity_shouldDelegateToRepoSave() {
+        DummyEntity in = new DummyEntity(null);
+        DummyEntity out = new DummyEntity("ID1");
+        when(mockRepo.save(in)).thenReturn(out);
+
+        DummyEntity result = service.saveEntity(in);
+
+        assertThat(result).isSameAs(out);
+        verify(mockRepo).save(in);
+    }
+
+    @Test
+    void deleteById_shouldDelegateToRepoDelete() {
+        doNothing().when(mockRepo).deleteById("ID2");
+
+        service.deleteById("ID2");
+
+        verify(mockRepo).deleteById("ID2");
+    }
+}

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/common/_super/BaseQueryServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/common/_super/BaseQueryServiceTest.java
@@ -1,0 +1,83 @@
+package com.notfound.lpickbackend.common._super;
+
+import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BaseQueryServiceTest {
+
+    // 1) 테스트용 엔티티: ID만 갖는 아주 단순한 자식 클래스
+    static class DummyEntity extends BaseEntity {
+        // BaseEntity 의 prePersist 로직을 피하려면
+        public DummyEntity(String id) { setId(id); }
+        public void setId(String id) { super.setId(id); }
+    }
+
+    // 2) BaseCommandService 를 구현한 아주 단순한 서브클래스
+    static class DummyService extends BaseQueryService<DummyEntity, String> {
+        private final JpaRepository<DummyEntity, String> repo;
+        public DummyService(JpaRepository<DummyEntity, String> repo) {
+            this.repo = repo;
+        }
+        @Override protected JpaRepository<DummyEntity, String> getRepository() {
+            return repo;
+        }
+        @Override protected ErrorCode notFoundErrorCode() {
+            return ErrorCode.NOT_FOUND_GEAR; // 실제로는 각 서비스에 맞는 코드로 사용
+        }
+    }
+
+    @Mock
+    private JpaRepository<DummyEntity, String> mockRepo;
+
+    private DummyService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DummyService(mockRepo);
+    }
+
+    @Test
+    void findById_whenExists_shouldReturn() {
+        DummyEntity found = new DummyEntity("ID3");
+        when(mockRepo.findById("ID3")).thenReturn(Optional.of(found));
+
+        DummyEntity result = service.findById("ID3");
+
+        assertThat(result).isSameAs(found);
+    }
+
+    @Test
+    void findById_whenNotExists_shouldThrow() {
+        when(mockRepo.findById("MISSING")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.findById("MISSING"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NOT_FOUND_GEAR);
+    }
+
+    @Test
+    void findAll_shouldDelegateToRepoFindAll() {
+        List<DummyEntity> list = List.of(new DummyEntity("A"), new DummyEntity("B"));
+        when(mockRepo.findAll()).thenReturn(list);
+
+        List<DummyEntity> result = service.findAll();
+
+        assertThat(result).isEqualTo(list);
+    }
+}

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/servicedata/command/application/service/GearCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/servicedata/command/application/service/GearCommandServiceTest.java
@@ -1,0 +1,65 @@
+package com.notfound.lpickbackend.servicedata.command.application.service;
+
+import com.notfound.lpickbackend.common.exception.CustomException;
+import com.notfound.lpickbackend.common.exception.ErrorCode;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
+import com.notfound.lpickbackend.servicedata.command.application.repository.GearCommandRepository;
+import com.notfound.lpickbackend.servicedata.query.service.GearClassQueryService;
+import com.notfound.lpickbackend.servicedata.query.service.GearQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class GearCommandServiceTest {
+
+    @Mock
+    private GearCommandRepository gearCommandRepository;
+
+    // baseService, baseEntity 리팩토링된 대상 서비스에는 @Spy 적용해야 테스트 추적 정상작동.
+    @Spy
+    @InjectMocks
+    private GearCommandService gearCommandService;
+
+    @Mock
+    private GearQueryService gearQueryService;
+
+    @Mock
+    private GearClassQueryService gearClassQueryService;
+
+    private final String GEAR_ID = "gear-1";
+
+    private Gear gear;
+
+    @BeforeEach
+    void setUp() {
+        gear = Gear.builder()
+                .id(GEAR_ID)
+                .isTemp(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("approveTempGearIfNotTempGear : tempGear가 아닌 Gear에 대해 approve를 시도하는 경우의 예외처리를 검증한다.")
+    void approveTempGearIfNotTempGear() {
+
+        given(gearQueryService.findById(GEAR_ID)).willReturn(gear);
+
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            gearCommandService.approveTempGear(GEAR_ID);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.IS_NOT_TEMP_GEAR);
+    }
+
+
+}

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/command/application/service/UserAlbumCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/command/application/service/UserAlbumCommandServiceTest.java
@@ -2,12 +2,9 @@ package com.notfound.lpickbackend.userinfo.command.application.service;
 
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserAlbum;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
-import com.notfound.lpickbackend.userinfo.command.repository.UserAlbumCommandRepository;
-import com.notfound.lpickbackend.userinfo.query.repository.UserAlbumQueryRepository;
-import com.notfound.lpickbackend.userinfo.query.repository.UserInfoQueryRepository;
 import com.notfound.lpickbackend.userinfo.query.service.UserAlbumQueryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandServiceTest.java
@@ -2,11 +2,8 @@ package com.notfound.lpickbackend.userinfo.command.application.service;
 
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
-import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserAlbum;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserGear;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
-import com.notfound.lpickbackend.userinfo.query.service.UserAlbumQueryService;
 import com.notfound.lpickbackend.userinfo.query.service.UserGearQueryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,8 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/command/application/service/UserGearCommandServiceTest.java
@@ -2,8 +2,10 @@ package com.notfound.lpickbackend.userinfo.command.application.service;
 
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserGear;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
+import com.notfound.lpickbackend.userinfo.command.application.domain.inherenceENUM.GearClass;
 import com.notfound.lpickbackend.userinfo.query.service.UserGearQueryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +29,8 @@ class UserGearCommandServiceTest {
 
 
     private UserGear mockUserGear;
+
+    private final GearClass className = GearClass.TURNTABLE;
 
     private final String oauthId1 = "oauth123";
     private final String oauthId2 = "oauth222";
@@ -56,11 +60,20 @@ class UserGearCommandServiceTest {
                 .tier(null)
                 .build();
 
+        com.notfound.lpickbackend.servicedata.command.application.domain.GearClass TURNTABLE =
+                com.notfound.lpickbackend.servicedata.command.application.domain.GearClass.builder()
+                        .className(GearClass.TURNTABLE.name())
+                        .build();
+
+        Gear mockGear =  Gear.builder()
+                .eqClass(TURNTABLE)
+                .build();
 
         mockUserGear = UserGear.builder()
                 .userGearId(userGearId)
-                .eq(null)
+                .eq(mockGear)
                 .oauth(mockUser1)
+                .isFavorite(false)
                 .build();
     }
 
@@ -77,5 +90,34 @@ class UserGearCommandServiceTest {
 
 
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN_RESOURCE_ACCESS);
+    }
+
+    @Test
+    void patchUserGearFavoriteToggle_IfDifferentUserRequested() {
+        given(userGearQueryService.findById(userGearId)).willReturn(mockUserGear);
+
+        // 접근시도 인원은 User2므로 에러 발생
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            userGearCommandService.patchUserGearFavoriteToggle(oauthId2, userGearId);
+        });
+
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN_RESOURCE_ACCESS);
+    }
+
+    @Test
+    void patchUserGearFavoriteToggle_IfAlreadyExsitsFavoriteGear() {
+
+        given(userGearQueryService.findGearDetailInfoById(userGearId)).willReturn(mockUserGear);
+        given(userGearQueryService.countUserGearFavoriteByClassName(oauthId1, className.name())).willReturn(1L);
+
+        // 접근시도 인원은 User2므로 에러 발생
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            userGearCommandService.patchUserGearFavoriteToggle(oauthId1, userGearId);
+        });
+
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_FULL_FAVORITE_GEAR);
+
     }
 }

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandServiceTest.java
@@ -1,8 +1,8 @@
 package com.notfound.lpickbackend.wiki.command.application.service;
 
-import com.notfound.lpickbackend.servicedata.command.domain.Album;
-import com.notfound.lpickbackend.servicedata.command.domain.Artist;
-import com.notfound.lpickbackend.servicedata.command.domain.Gear;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Album;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Artist;
+import com.notfound.lpickbackend.servicedata.command.application.domain.Gear;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
 import com.notfound.lpickbackend.common.exception.CustomException;
 import com.notfound.lpickbackend.common.exception.ErrorCode;

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/wiki/command/application/service/WikiDomainCommandServiceTest.java
@@ -131,7 +131,7 @@ class WikiDomainCommandServiceTest {
         album.setWiki(dummyWiki);
 
         Gear gear = mock(Gear.class);
-        gear.setEqId("album-1");
+        gear.setId("album-1");
         gear.setWiki(dummyWiki);
 
         dummyWiki.setArtist(artist);


### PR DESCRIPTION
# 📌 PR 제목
기존 사용자 기기 관련 기능(UserGear) 리팩토링
# 🤔 연관된 이슈
https://github.com/404-Not-Found-DMU/lpick-backend/issues/22 - 기존 사용자 기기 관련 기능(UserGear) 구현 수정

# ✨ 요약
이전 이슈에서 다루었던 UserGear를 추가적으로 수정했습니다.
사용자는 이제 임시로 Gear를 등록할 수 있습니다.

Gear를 관리 가능한 Create, Update, Delete 기능 추가되었습니다.

# ✅ 주요 작업
### 기존 작업 내역

사용자가 각 종류별로 여러 개의 UserGear를 지닐 수 있도록 수정
사용자가 종류별로 자신이 마이페이지에 표기하고자 하는 1개의 UserGear를 favorite Gear로 설정할 수 있도록 기능 추가 및 DB 수정
사용자가 원하는 Gear가 없는 경우 별도의 tempGear를 Gear 엔티티에 구현 가능하도록 기능 구현 및 DB 수정(flag 목적 컬럼 추가)

 
### 추가작업내역

#21 에서 진행할 리팩토링 코드를 선제적으로 도입 시도. 관련 리팩토링에 대해 의견 코드리뷰로 제공해주시면 감사하겠습니다.


# 🧪 테스트 방법
http 테스트
<img width="858" height="387" alt="image" src="https://github.com/user-attachments/assets/9db65e17-32c5-4b72-b42c-1ac6ec6a1303" />



테스트 코드 자체 작성 및 동작 확인
<img width="356" height="176" alt="image" src="https://github.com/user-attachments/assets/d1f4a9b1-6d46-4c5a-b522-a73e11b2b7cd" />
