### PR TITLE
[Feat/wiki] #45 : diff 리팩토링과 기타 최우선과제 해결

### DIFF
--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserAlbum.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/command/application/domain/entity/UserAlbum.java
@@ -7,24 +7,29 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.Instant;
 import java.util.UUID;
 
 
 @NoArgsConstructor
 @Getter
 @Setter
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @Table(name = "user_album")
 public class UserAlbum {
 
     @Builder
-    public UserAlbum(String userAlbumId, String recordFile, boolean isFavorite, Album album, UserInfo oauth) {
+    public UserAlbum(String userAlbumId, String recordFile, boolean isFavorite, Instant createdAt, Album album, UserInfo oauth) {
         this.userAlbumId = userAlbumId;
         this.recordFile = recordFile;
+        this.isFavorite = isFavorite;
+        this.createdAt = createdAt;
         this.album = album;
         this.oauth = oauth;
-        this.isFavorite = isFavorite;
     }
 
     @PrePersist
@@ -43,6 +48,10 @@ public class UserAlbum {
 
     @Column(name = "is_favorite") // 10개까지만 설정 가능하게 하기. + 추후 favorite 지정 시간 등으로 정렬조건 추가 할것.
     private boolean isFavorite;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "album_id", nullable = false)

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/controller/UserAlbumQueryController.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/controller/UserAlbumQueryController.java
@@ -2,6 +2,7 @@ package com.notfound.lpickbackend.userinfo.query.controller;
 
 import com.notfound.lpickbackend.common._wrapper.BlindableResponse;
 import com.notfound.lpickbackend.security.util.UserInfoUtil;
+import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedHeader;
 import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse;
 import com.notfound.lpickbackend.userinfo.query.service.UserAlbumQueryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,14 +26,14 @@ public class UserAlbumQueryController {
 
         @GetMapping("/user-album")
         @Operation(summary = "사용자 소유 앨범 페이지네이션 조회", description = "페이지네이션을 기반으로 사용자가 소유한 앨범의 목록 조회 가능. 상세 조회를 바로 제공.(필요시 제목 및 커버만 반환으로 수정가능)")
-        public ResponseEntity<Page<UserAlbumOwnedResponse>> getUserOwnedAlbumList(
+        public ResponseEntity<Page<UserAlbumOwnedHeader>> getUserOwnedAlbumList(
                 @RequestParam("page")int page,
                 @RequestParam("size")int size
         ) {
-                Page<UserAlbumOwnedResponse> userAlbumList
+                Page<UserAlbumOwnedHeader> userAlbumList
                         = userAlbumQueryService.getOwnAlbumList(
                                 UserInfoUtil.getOAuthId(),
-                                PageRequest.of(page, size)
+                                PageRequest.of(page - 1, size)
                         );
 
                 return ResponseEntity.status(HttpStatus.OK).body(userAlbumList);
@@ -40,7 +41,7 @@ public class UserAlbumQueryController {
 
         @GetMapping("/my-page/{oauthId}/user-album")
         @Operation(summary = "대상 사용자의 소유 앨범 페이지네이션 조회", description = "설정에 따라 표기되지 않을 수 있음. 페이지네이션을 기반으로 사용자가 소유한 앨범의 목록 조회 가능. 상세 조회를 바로 제공.(필요시 제목 및 커버만 반환으로 수정가능)")
-        public ResponseEntity<BlindableResponse<Page<UserAlbumOwnedResponse>>> getUserOwnedAlbumListByOauthId(
+        public ResponseEntity<BlindableResponse<Page<UserAlbumOwnedHeader>>> getUserOwnedAlbumListByOauthId(
                 @PathVariable("oauthId")String oauthId,
                 @RequestParam("page")int page,
                 @RequestParam("size")int size
@@ -48,7 +49,7 @@ public class UserAlbumQueryController {
                 return ResponseEntity.status(HttpStatus.OK).body(
                         userAlbumQueryService.getUserAlbumListByOauthId(
                                 oauthId,
-                                PageRequest.of(page, size)
+                                PageRequest.of(page - 1, size)
                         )
                 );
         }
@@ -65,7 +66,7 @@ public class UserAlbumQueryController {
         /** 사용자가 설정한 favorite 리스트 제공.*/
         @GetMapping("/user-album/favorite")
         @Operation(summary = "사용자가 소유한 favorite 앨범 목록 조회", description = "사용자가 추천 앨범으로 선정해둔 앨범의 목록만 조회.(최대 10개)")
-        public ResponseEntity<List<UserAlbumOwnedResponse>> getUserOwnedFavoriteAlbum(
+        public ResponseEntity<List<UserAlbumOwnedHeader>> getUserOwnedFavoriteAlbum(
 
         ) {
                 return ResponseEntity.status(HttpStatus.OK).body(userAlbumQueryService.getUserFavoriteAlbumList(UserInfoUtil.getOAuthId()));

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/dto/response/UserAlbumOwnedHeader.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/dto/response/UserAlbumOwnedHeader.java
@@ -1,0 +1,20 @@
+package com.notfound.lpickbackend.userinfo.query.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UserAlbumOwnedHeader {
+    private String userAlbumId;
+    private String name;
+    private String profile; // 앨범커버
+    private String artistName;
+    private boolean isFavorite;
+
+    public UserAlbumOwnedHeader(String userAlbumId, String name, String profile, String artistName, boolean isFavorite) {
+        this.userAlbumId = userAlbumId;
+        this.name = name;
+        this.profile = profile;
+        this.artistName = artistName;
+        this.isFavorite = isFavorite;
+    }
+}

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/dto/response/UserAlbumOwnedResponse.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/dto/response/UserAlbumOwnedResponse.java
@@ -12,6 +12,7 @@ public class UserAlbumOwnedResponse {
     private String userAlbumId;
     private String name;
     private String profile; // 앨범커버
+    private Instant createdAt;
     private String artistName;
     private String recordFile; // 유무에 따라 null로 기입.
     private Instant releaseDate;
@@ -19,10 +20,11 @@ public class UserAlbumOwnedResponse {
     private String label;
     private boolean isFavorite;
 
-    public UserAlbumOwnedResponse(String userAlbumId, String name, String profile, String artistName, String recordFile, Instant releaseDate, String releaseCountry, String label, boolean isFavorite) {
+    public UserAlbumOwnedResponse(String userAlbumId, String name, String profile, Instant createdAt, String artistName, String recordFile, Instant releaseDate, String releaseCountry, String label, boolean isFavorite) {
         this.userAlbumId = userAlbumId;
         this.name = name;
         this.profile = profile;
+        this.createdAt = createdAt;
         this.artistName = artistName;
         this.recordFile = recordFile;
         this.releaseDate = releaseDate;

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserAlbumQueryRepository.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/repository/UserAlbumQueryRepository.java
@@ -1,6 +1,7 @@
 package com.notfound.lpickbackend.userinfo.query.repository;
 
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserAlbum;
+import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedHeader;
 import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,68 +17,96 @@ public interface UserAlbumQueryRepository extends JpaRepository<UserAlbum, Strin
 
     // JPQL로 뽑아내는 테이블들을 추후 View 테이블을 사용해보는 걸 논의해보는 것도 좋을 듯 합니다.
     /** 사용자가 소유중인 앨범의 정보(앨범명, 앨범사진, 아티스트명, 녹음파일, 발매일, 발매국가, 레이블) 제공 */
-    @Query("""
-    SELECT new com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse(
-        ua.userAlbumId,
-        al.name,
-        al.profile,
-        ar.name,
-        ua.recordFile,
-        al.releaseDate,
-        al.releaseCountry,
-        al.label,
-        ua.isFavorite
+    @Query(
+            value = """
+  select new com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedHeader(
+    ua.userAlbumId,
+    al.name,
+    al.profile,
+    case
+      when count(distinct ar.artistId) > 1 then
+        concat(
+          min(ar.name),
+          concat(' + 외 ', concat( (count(distinct ar.artistId) - 1), '개 아티스트'))
+        )
+      when count(distinct ar.artistId) = 1 then
+        min(ar.name)
+      else
+        '(아티스트 미상)'
+    end,
+    ua.isFavorite
+  )
+  from UserAlbum ua
+    join ua.album al
+    left join ArtistAlbum aral on aral.album = al
+    left join aral.artist ar
+  where ua.oauth.oauthId = :oauthId
+  group by
+    ua.userAlbumId,
+    al.name, al.profile,
+    ua.isFavorite
+  """,
+            countQuery = """
+  select count(distinct ua.userAlbumId)
+  from UserAlbum ua
+  where ua.oauth.oauthId = :oauthId
+  """
     )
-    FROM UserAlbum ua
-    LEFT JOIN Album al ON al.albumId = ua.album.albumId
-    LEFT JOIN ArtistAlbum aral ON aral.album.albumId = ua.album.albumId
-    LEFT JOIN Artist ar ON ar.artistId = aral.artist.artistId
-    WHERE ua.oauth.oauthId = :oauthId
-    GROUP BY al.albumId, aral.album.albumId, ar.artistId
-    """)
-    public Page<UserAlbumOwnedResponse> findAllUserAlbumByOauthId(String oauthId, Pageable pageable);
+    public Page<UserAlbumOwnedHeader> findAllUserAlbumByOauthId(String oauthId, Pageable pageable);
 
+    // 아티스트가 여러명인경우 , 로 묶어 하나의 string으로 전달. artist 없으면 아티스트 미상으로 전달
     @Query("""
-    SELECT new com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse(
-        ua.userAlbumId,
-        al.name,
-        al.profile,
-        ar.name,
-        ua.recordFile,
-        al.releaseDate,
-        al.releaseCountry,
-        al.label,
-        ua.isFavorite
-    )
-    FROM UserAlbum ua
-    LEFT JOIN Album al ON al.albumId = ua.album.albumId
-    LEFT JOIN ArtistAlbum aral ON aral.album.albumId = ua.album.albumId
-    LEFT JOIN Artist ar ON ar.artistId = aral.artist.artistId
-    WHERE ua.userAlbumId = :userAlbumId
-    GROUP BY al.albumId, aral.album.albumId, ar.artistId
-    """)
+select new com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse(
+  ua.userAlbumId,
+  al.name,
+  al.profile,
+  ua.createdAt,
+  coalesce( cast(function('string_agg', ar.name, ', ') as string), '(아티스트 미상)' ),
+  ua.recordFile,
+  al.releaseDate,
+  al.releaseCountry,
+  al.label,
+  ua.isFavorite
+)
+from UserAlbum ua
+  join ua.album al
+  left join ArtistAlbum aral on aral.album = al
+  left join aral.artist ar
+where ua.userAlbumId = :userAlbumId
+group by
+  ua.userAlbumId, al.name, al.profile, ua.createdAt,
+  ua.recordFile, al.releaseDate, al.releaseCountry, al.label, ua.isFavorite
+""")
     Optional<UserAlbumOwnedResponse> findUserAlbumById(String userAlbumId);
 
     @Query("""
-    SELECT new com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse(
-        ua.userAlbumId,
-        al.name,
-        al.profile,
-        ar.name,
-        ua.recordFile,
-        al.releaseDate,
-        al.releaseCountry,
-        al.label,
-        ua.isFavorite
-    )
-    FROM UserAlbum ua
-    LEFT JOIN Album al ON al.albumId = ua.album.albumId
-    LEFT JOIN ArtistAlbum aral ON aral.album.albumId = ua.album.albumId
-    LEFT JOIN Artist ar ON ar.artistId = aral.artist.artistId
-    WHERE ua.oauth.oauthId = :oauthId AND ua.isFavorite = TRUE
-    GROUP BY al.albumId, aral.album.albumId, ar.artistId
-    """)
-    List<UserAlbumOwnedResponse> findAllUserAlbumByIsFavorite(String oauthId);
+select new com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedHeader(
+  ua.userAlbumId,
+  al.name,
+  al.profile,
+  case
+    when count(distinct ar.artistId) > 1 then
+      concat(min(ar.name), concat(' + 외 ', concat((count(distinct ar.artistId) - 1), '개 아티스트')))
+    when count(distinct ar.artistId) = 1 then
+      min(ar.name)
+    else
+      '(아티스트 미상)'
+  end,
+  ua.isFavorite
+)
+from UserAlbum ua
+  join ua.album al
+  left join ArtistAlbum aral on aral.album = al
+  left join aral.artist ar
+where ua.oauth.oauthId = :oauthId
+  and ua.isFavorite = true
+group by
+  ua.userAlbumId,
+  al.name, al.profile,
+  ua.isFavorite
+order by ua.createdAt desc, ua.userAlbumId desc
+""")
+    List<UserAlbumOwnedHeader> findAllUserAlbumByIsFavorite(String oauthId);
 
     /**
      * 장르별 보유 앨범 수를 (장르명, 개수) 쌍의 List<Object[]> 로 리턴

--- a/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserAlbumQueryService.java
+++ b/lpick-backend/src/main/java/com/notfound/lpickbackend/userinfo/query/service/UserAlbumQueryService.java
@@ -6,6 +6,7 @@ import com.notfound.lpickbackend.common.exception.ErrorCode;
 import com.notfound.lpickbackend.servicedata.query.service.GenreQueryService;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserAlbum;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserSetting;
+import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedHeader;
 import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse;
 import com.notfound.lpickbackend.userinfo.query.repository.UserAlbumQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -44,20 +45,20 @@ public class UserAlbumQueryService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserAlbumOwnedResponse> getUserFavoriteAlbumList(String oAuthId) {
+    public List<UserAlbumOwnedHeader> getUserFavoriteAlbumList(String oAuthId) {
         return userAlbumQueryReposiory.findAllUserAlbumByIsFavorite(oAuthId);
     }
 
     /** 요청자 본인의 앨범 목록 내역 가져올때만 사용. */
     @Transactional(readOnly = true)
-    public Page<UserAlbumOwnedResponse> getOwnAlbumList(String oAuthId, Pageable pageable) {
+    public Page<UserAlbumOwnedHeader> getOwnAlbumList(String oAuthId, Pageable pageable) {
 
         return userAlbumQueryReposiory.findAllUserAlbumByOauthId(oAuthId, pageable);
     }
 
     @Transactional(readOnly = true)
     /** 타인 마이페이지 진입 시 컬렉션 획득 위해 사용 */
-    public BlindableResponse<Page<UserAlbumOwnedResponse>> getUserAlbumListByOauthId(String oAuthId, Pageable pageable) {
+    public BlindableResponse<Page<UserAlbumOwnedHeader>> getUserAlbumListByOauthId(String oAuthId, Pageable pageable) {
         UserSetting userSetting = userSettingQueryService.findById(oAuthId);
 
         if(!userSetting.getMyPagePrivacySetting().isUserAllowViewCollection())

--- a/lpick-backend/src/main/resources/schema.sql
+++ b/lpick-backend/src/main/resources/schema.sql
@@ -123,7 +123,8 @@ CREATE TABLE IF NOT EXISTS user_album (
                                           record_file	varchar(200)		NULL,
                                           is_favorite boolean         NOT NULL DEFAULT FALSE,
                                           album_id	varchar(40)		NOT NULL,
-                                          oauth_id	varchar(40)		NOT NULL
+                                          oauth_id	varchar(40)		NOT NULL,
+                                          created_at	timestamp		NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS review_like (

--- a/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/query/service/UserAlbumQueryServiceTest.java
+++ b/lpick-backend/src/test/java/com/notfound/lpickbackend/userinfo/query/service/UserAlbumQueryServiceTest.java
@@ -4,6 +4,7 @@ import com.notfound.lpickbackend.common._wrapper.BlindableResponse;
 import com.notfound.lpickbackend.userinfo.command.application.domain.embed.MyPagePrivacySetting;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserInfo;
 import com.notfound.lpickbackend.userinfo.command.application.domain.entity.UserSetting;
+import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedHeader;
 import com.notfound.lpickbackend.userinfo.query.dto.response.UserAlbumOwnedResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -59,7 +60,7 @@ class UserAlbumQueryServiceTest {
     void getUserAlbumListByOauthIdWhenUserWantBlind() {
         given(userSettingQueryService.findById(oauthId)).willReturn(userSetting);
 
-        BlindableResponse<Page<UserAlbumOwnedResponse>> testResult
+        BlindableResponse<Page<UserAlbumOwnedHeader>> testResult
                 = userAlbumQueryService.getUserAlbumListByOauthId(
                         oauthId, PageRequest.of(1, 10));
 


### PR DESCRIPTION
## 📌 PR 제목 
[Feat/wiki] #45 : diff 리팩토링과 기타 최우선과제 해결
---
## 🤔 연관된 이슈
#45 

---

## ✨ 요약
#45에 의거, text -> jsonb로 변경된 wiki content에 대해 diff 알고리즘 동작하도록 리팩토링 수행(미완)

userAlbum Query 계열의 요청들이 정상적으로 동작하지 않던 문제 fix(완)
---

## ✅ 주요 작업

#45 
- [ ] 

- 기타 내역
- [x] userAlbumQuery - UserAlbum에 대해 createdAt 추가
- [x] userAlbumQuery - userAlbum의 목록(페이지)과 상세 반환 목적 dto 세분화

---

## 🧪 테스트 방법

- [ ] Swagger에서 확인

---

## 🔍 참고 사항 및 리뷰 요구사항
아직 구현중입니다.

이미지 덮어씌워져 롤백하는 문제 해결하기위해, 올려주신 최신 dev 와 미리 선제 병합 후 풀리퀘 작성합니다.
